### PR TITLE
Implement issue #43 with conditional homepage behavior because AI Village currently has no active sponsors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Add volunteer profiles to `src/content/volunteers/` with `first_name`, `last_nam
 
 ### Sponsors
 
-Add sponsors to `src/content/sponsors/` with `name`, optional `logo`, `url`, `tier`, `description`, and `active`. Active sponsors appear at `/sponsors/`; each sponsor also gets a detail page at `/sponsors/<slug>/`.
+Add sponsors to `src/content/sponsors/` with `name`, required `status` (`current` or `past`), and optional `logo`, `url`, `tier`, and `description`. Current sponsors appear on the homepage and `/sponsors/`; past sponsors appear in the past sponsors section. Each sponsor also gets a detail page at `/sponsors/<slug>/`.
 
 ### Workshops
 

--- a/src/components/SponsorGrid.astro
+++ b/src/components/SponsorGrid.astro
@@ -2,16 +2,51 @@
 import type { SponsorEntry } from "../utils/site";
 import { sponsorPath } from "../utils/site";
 
-const { sponsors } = Astro.props as { sponsors: SponsorEntry[] };
+type LinkMode = "external" | "detail" | "none";
+
+const { sponsors, linkMode = "external", compact = false } = Astro.props as {
+  sponsors: SponsorEntry[];
+  linkMode?: LinkMode;
+  compact?: boolean;
+};
+
+const gridStyle = compact
+  ? "display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin: 1.5rem 0;"
+  : "display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.5rem; margin: 2rem 0;";
+const cardStyle = compact ? "align-items: center; padding: 1rem;" : "align-items: center;";
+const logoBoxStyle = compact
+  ? "width: 150px; height: 100px; border-radius: 5px; background: #fff; display: flex; align-items: center; justify-content: center; border: 1px solid #00ff00; padding: 16px;"
+  : "width: 240px; height: 240px; border-radius: 10%; background: #fff; display: flex; align-items: center; justify-content: center; border: 2px solid #00ff00; padding: 20px;";
+const logoStyle = compact ? "max-width: 120px; max-height: 70px; object-fit: contain;" : "max-width: 200px; max-height: 200px; object-fit: contain;";
+const nameStyle = compact ? "font-size: 1rem; margin: 0.75rem 0 0;" : undefined;
 ---
 
-<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.5rem; margin: 2rem 0;">
-  {sponsors.map((sponsor) => (
-    <div class="card" style="align-items: center;">
-      <a href={sponsorPath(sponsor)} style="width: 240px; height: 240px; border-radius: 10%; background: #fff; display: flex; align-items: center; justify-content: center; border: 2px solid #00ff00; padding: 20px;">
-        {sponsor.data.logo && <img src={`/assets/images/logos/${sponsor.data.logo}`} alt={`${sponsor.data.name} logo`} />}
-      </a>
-      <h3><a href={sponsorPath(sponsor)}>{sponsor.data.name}</a></h3>
-    </div>
-  ))}
+<div style={gridStyle}>
+  {sponsors.map((sponsor) => {
+    const href = linkMode === "detail" ? sponsorPath(sponsor) : linkMode === "external" ? sponsor.data.url : undefined;
+    const target = linkMode === "external" && href ? "_blank" : undefined;
+    const rel = linkMode === "external" && href ? "noopener noreferrer" : undefined;
+    const logoContent = sponsor.data.logo ? (
+      <img src={`/assets/images/logos/${sponsor.data.logo}`} alt={`${sponsor.data.name} logo`} style={logoStyle} />
+    ) : (
+      <span>{sponsor.data.name}</span>
+    );
+
+    return (
+      <div class="card" style={cardStyle}>
+        {href ? (
+          <a href={href} target={target} rel={rel} style={logoBoxStyle}>
+            {logoContent}
+          </a>
+        ) : (
+          <div style={logoBoxStyle}>
+            {logoContent}
+          </div>
+        )}
+        <h3 style={nameStyle}>
+          {href ? <a href={href} target={target} rel={rel}>{sponsor.data.name}</a> : sponsor.data.name}
+        </h3>
+      </div>
+    );
+  })}
 </div>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -54,14 +54,34 @@ const volunteers = defineCollection({
 
 const sponsors = defineCollection({
   loader: glob({ pattern: "**/*.{md,mdx,markdown}", base: "./src/content/sponsors" }),
-  schema: z.object({
-    name: z.string(),
-    logo: z.string().optional(),
-    url: z.url().optional(),
-    tier: z.string().optional(),
-    description: z.union([z.string(), z.boolean()]).optional(),
-    active: z.boolean().default(true),
-  }),
+  schema: z
+    .object({
+      name: z.string(),
+      status: z.enum(["current", "past"]),
+      logo: z.string().optional(),
+      url: z.url().optional(),
+      tier: z.string().optional(),
+      description: z.union([z.string(), z.boolean()]).optional(),
+    })
+    .superRefine((data, ctx) => {
+      if (data.status !== "current") return;
+
+      if (!data.logo) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["logo"],
+          message: "Current sponsors must include a logo.",
+        });
+      }
+
+      if (!data.url) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["url"],
+          message: "Current sponsors must include a URL.",
+        });
+      }
+    }),
 });
 
 const schedules = defineCollection({

--- a/src/content/sponsors/reality_defender.md
+++ b/src/content/sponsors/reality_defender.md
@@ -1,5 +1,7 @@
 ---
 name: Reality Defender
+status: past
 logo: RD_Logo.svg
+url: https://www.realitydefender.com/
 description: false # If you don't want to include a bio, change this to false.
 ---

--- a/src/pages/community/index.astro
+++ b/src/pages/community/index.astro
@@ -30,4 +30,11 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
     <h2 style="margin-top: 0;">Before Participating</h2>
     <p>Read the <a href="/about/conduct/">code of conduct</a> and help keep AI Village welcoming for participants, speakers, sponsors, and volunteers.</p>
   </div>
+
+  <section aria-labelledby="community-support" style="margin-top: 1.5rem;">
+    <h2 id="community-support">Community Support</h2>
+    <p>
+      AI Village is supported by current and past sponsors, volunteers, researchers, builders, and community partners. Current and past sponsor information is available on the <a href="/sponsors/">Sponsors page</a>.
+    </p>
+  </section>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,11 +3,11 @@ import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import DateBadge from "../components/DateBadge.astro";
 import SponsorGrid from "../components/SponsorGrid.astro";
-import { canonicalPostPath, eventPath, excerptFromBody, formatShortDate, sortEventsAscending, sortPosts } from "../utils/site";
+import { canonicalPostPath, eventPath, excerptFromBody, formatShortDate, getCurrentSponsors, sortEventsAscending, sortPosts } from "../utils/site";
 
 const events = sortEventsAscending(await getCollection("events"));
 const posts = sortPosts(await getCollection("blog", ({ data }) => !data.draft));
-const sponsors = (await getCollection("sponsors")).filter((sponsor) => sponsor.data.active);
+const currentSponsors = getCurrentSponsors(await getCollection("sponsors"));
 const now = new Date();
 const upcomingEvent = events.find((event) => event.data.date.getTime() >= now.getTime());
 const latestPost = posts[0];
@@ -85,6 +85,34 @@ const latestPost = posts[0];
       <p>Building bridges between hackers, data scientists, researchers, and policy makers.</p>
     </div>
   </div>
+
+  {currentSponsors.length > 0 ? (
+    <>
+      <hr />
+
+      <section aria-labelledby="current-sponsors">
+        <h2 id="current-sponsors">CURRENT SPONSORS</h2>
+        <p>
+          Our Current Sponsors are the companies that actively contribute to the mission of AI Village. Learn how to join our community and see past sponsors here:
+          {" "}
+          <a href="/sponsors/">Sponsors</a>
+        </p>
+        <SponsorGrid sponsors={currentSponsors} linkMode="external" compact />
+      </section>
+    </>
+  ) : (
+    <>
+      <hr />
+
+      <section aria-labelledby="support-ai-village">
+        <h2 id="support-ai-village">SUPPORT AI VILLAGE</h2>
+        <p>
+          AI Village is supported by volunteers, researchers, builders, and organizations that contribute to AI security education and research.
+        </p>
+        <p><a href="/sponsors/" style="color: #00ffff;">Sponsor AI Village →</a></p>
+      </section>
+    </>
+  )}
 
   <hr />
 

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -29,7 +29,9 @@ function loc(path: string) {
 export async function GET() {
   const events = sortEventsAscending(await getCollection("events"));
   const posts = [...(await getCollection("blog", ({ data }) => !data.draft))].sort((a, b) => a.data.date.getTime() - b.data.date.getTime());
-  const sponsors = (await getCollection("sponsors")).filter((sponsor) => sponsor.data.active);
+  const sponsors = (await getCollection("sponsors")).filter(
+    (sponsor) => sponsor.data.status === "current" || sponsor.data.status === "past",
+  );
   const schedules = await getCollection("schedules");
 
   const urls = Array.from(new Set([

--- a/src/pages/sponsors/index.astro
+++ b/src/pages/sponsors/index.astro
@@ -2,17 +2,37 @@
 import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import SponsorGrid from "../../components/SponsorGrid.astro";
+import { getCurrentSponsors, getPastSponsors } from "../../utils/site";
 
-const sponsors = (await getCollection("sponsors")).filter((sponsor) => sponsor.data.active);
+const sponsors = await getCollection("sponsors");
+const currentSponsors = getCurrentSponsors(sponsors);
+const pastSponsors = getPastSponsors(sponsors);
 ---
 
-<BaseLayout title="Sponsors" canonical="/sponsors/" description="Current AI Village sponsors from the site sponsor collection.">
+<BaseLayout title="Sponsors" canonical="/sponsors/" description="Current and past AI Village sponsors from the site sponsor collection.">
   <h1>Sponsors</h1>
   <p>
-    This page reflects sponsor information currently present in the AI Village website repository. It avoids publishing sponsorship tiers or benefits that are not yet represented in source content.
+    AI Village acknowledges organizations that currently support, or have previously supported, the community's AI security education and research mission.
   </p>
-  <SponsorGrid sponsors={sponsors} />
   <p>
-    For sponsor updates or corrections, contact the AI Village team through the community channels.
+    Interested in supporting AI Village? Start with the <a href="/community/">community page</a> to connect with the organizing team.
   </p>
+
+  <section aria-labelledby="current-sponsors">
+    <h2 id="current-sponsors">Current Sponsors</h2>
+    {currentSponsors.length > 0 ? (
+      <SponsorGrid sponsors={currentSponsors} linkMode="external" />
+    ) : (
+      <p>Current sponsor information is being finalized.</p>
+    )}
+  </section>
+
+  <section aria-labelledby="past-sponsors">
+    <h2 id="past-sponsors">Past Sponsors</h2>
+    {pastSponsors.length > 0 ? (
+      <SponsorGrid sponsors={pastSponsors} linkMode="external" />
+    ) : (
+      <p>Past sponsor information is being finalized.</p>
+    )}
+  </section>
 </BaseLayout>

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -97,6 +97,18 @@ export function sponsorPath(sponsor: SponsorEntry) {
   return `/sponsors/${slugify(sponsor.data.name || stripDatePrefix(sponsor.id))}/`;
 }
 
+function sortSponsorsByName(sponsors: SponsorEntry[]) {
+  return [...sponsors].sort((a, b) => a.data.name.localeCompare(b.data.name));
+}
+
+export function getCurrentSponsors(sponsors: SponsorEntry[]) {
+  return sortSponsorsByName(sponsors.filter((sponsor) => sponsor.data.status === "current"));
+}
+
+export function getPastSponsors(sponsors: SponsorEntry[]) {
+  return sortSponsorsByName(sponsors.filter((sponsor) => sponsor.data.status === "past"));
+}
+
 export function schedulePath(schedule: ScheduleEntry) {
   const id = schedule.id.replace(/\.(md|mdx|markdown)$/i, "");
   const route = scheduleRouteForId(id);


### PR DESCRIPTION
When there are no current sponsors, the homepage shows a restrained `SUPPORT AI VILLAGE` CTA linking to `/sponsors/` rather than an empty sponsor logo wall. When a sponsor entry is later added with `status: current`, `logo`, and `url`, the homepage automatically renders the `CURRENT SPONSORS` section with the required attribution sentence and direct external sponsor links.

This PR also replaces the unsafe `active: true` default with required `status: current | past`, preserves Reality Defender as a past sponsor, splits `/sponsors/` into Current/Past sections, validates that current sponsors have a logo and URL, and links sponsor grids directly to sponsor homepages.