### PR TITLE
45 create defcon34 page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 .env
 .env.*
 .direnv/
+.pnpm-store/

--- a/src/content/events/defcon34.md
+++ b/src/content/events/defcon34.md
@@ -1,0 +1,21 @@
+---
+title: "AI Village @ DEF CON 34"
+date: 2026-08-06
+description: "Join AI Village at DEF CON 34 for demos, CTF, and a new poster track on adversarial attacks against agents and agentic systems."
+location: "Las Vegas, NV"
+layout: post
+---
+
+DEF CON 34 runs August 6–9, 2026 in Las Vegas, NV. AI Village will be there with demos, CTF activity, and community programming for researchers, builders, defenders, sponsors, and volunteers working on practical AI security.
+
+## AI Village @ DEF CON 34: Call for Posters
+
+AI Village is opening a poster track themed **Adversarial Attacks Against Agents and Agentic Systems**. We welcome in-progress research, negative results, reproductions, novel taxonomies, threat models, tooling, evaluations, and related agentic AI security work.
+
+The CFP closes June 14, 2026. Acceptance notifications are expected June 28, 2026. The poster session will take place during DEF CON 34, August 6–9, 2026.
+
+## Get involved
+
+- [Submit a poster proposal](https://easychair.org/cfp/aiv8) for the DEF CON 34 poster track.
+- [Respond to the DEF CON 34 call for volunteers](https://forms.gle/sFyr1rVeqKAPXhG4A) to help with village participation.
+- [Join the AI Village community](/community/) to stay connected before and after DEF CON.

--- a/src/data/redirects.ts
+++ b/src/data/redirects.ts
@@ -24,6 +24,7 @@ export const staticRedirectGroups: RedirectGroup[] = [
       { from: "/events/defcon30/", to: "/events/defcon-30/" },
       { from: "/events/defcon32/", to: "/events/defcon-32/" },
       { from: "/events/defcon33/", to: "/events/defcon-33/" },
+      { from: "/events/defcon34/", to: "/events/defcon-34/" },
     ],
   },
   {

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -82,6 +82,7 @@ const eventSlugOverrides: Record<string, string> = {
   defcon30: "defcon-30",
   defcon32: "defcon-32",
   defcon33: "defcon-33",
+  defcon34: "defcon-34",
 };
 
 export function canonicalEventSlug(event: EventEntry) {


### PR DESCRIPTION
## Summary
- Added DEF CON 34 event content.
- Canonicalized the event route to `/events/defcon-34/`.
- Added `/events/defcon34/` as a compatibility redirect.
- Added CFP, call-for-volunteers, and community CTAs.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm lint`

Notes:
- Build passed redirect verification and internal-link checks.
- Lint passed with 2 pre-existing warnings in `src/pages/index.astro`.
- Local Node `v26.0.0` emitted expected engine/deprecation warnings; repo expects Node `24.x`.