### PR TITLE
Convert color tokens to runtime CSS variables

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -11,13 +11,13 @@ const excerpt = post.data.description ?? post.data.excerpt ?? excerptFromBody(po
     <a href={canonicalPostPath(post)}>{post.data.title}</a>
   </h2>
   <div class="post-meta">
-    {post.data.author && <span style="color: #00ff00;">{Array.isArray(post.data.author) ? post.data.author.join(", ") : post.data.author}</span>}
+    {post.data.author && <span style="color: var(--aiv-legacy-green);">{Array.isArray(post.data.author) ? post.data.author.join(", ") : post.data.author}</span>}
     {post.data.author && post.data.date && " • "}
     <time datetime={post.data.date.toISOString()}>{formatDate(post.data.date)}</time>
-    {post.data.category && <> • <span style="color: #ffff00;">#{post.data.category}</span></>}
+    {post.data.category && <> • <span style="color: var(--aiv-warning);">#{post.data.category}</span></>}
   </div>
   <div class="post-excerpt">{excerpt}</div>
   <div style="margin-top: 1rem;">
-    <a href={canonicalPostPath(post)} style="color: #00ffff;">Read more →</a>
+    <a href={canonicalPostPath(post)} style="color: var(--aiv-action-primary);">Read more →</a>
   </div>
 </article>

--- a/src/components/SponsorGrid.astro
+++ b/src/components/SponsorGrid.astro
@@ -15,8 +15,8 @@ const gridStyle = compact
   : "display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.5rem; margin: 2rem 0;";
 const cardStyle = compact ? "align-items: center; padding: 1rem;" : "align-items: center;";
 const logoBoxStyle = compact
-  ? "width: 150px; height: 100px; border-radius: 5px; background: #fff; display: flex; align-items: center; justify-content: center; border: 1px solid #00ff00; padding: 16px;"
-  : "width: 240px; height: 240px; border-radius: 10%; background: #fff; display: flex; align-items: center; justify-content: center; border: 2px solid #00ff00; padding: 20px;";
+  ? "width: 150px; height: 100px; border-radius: 5px; background: #fff; display: flex; align-items: center; justify-content: center; border: 1px solid var(--aiv-legacy-green); padding: 16px;"
+  : "width: 240px; height: 240px; border-radius: 10%; background: #fff; display: flex; align-items: center; justify-content: center; border: 2px solid var(--aiv-legacy-green); padding: 20px;";
 const logoStyle = compact ? "max-width: 120px; max-height: 70px; object-fit: contain;" : "max-width: 200px; max-height: 200px; object-fit: contain;";
 const nameStyle = compact ? "font-size: 1rem; margin: 0.75rem 0 0;" : undefined;
 ---

--- a/src/components/VolunteerCard.astro
+++ b/src/components/VolunteerCard.astro
@@ -7,25 +7,25 @@ const initials = `${volunteer.data.first_name.slice(0, 1)}${volunteer.data.last_
 const fullName = `${volunteer.data.first_name} ${volunteer.data.last_name}`;
 ---
 
-<div class="team-member" style="display: flex; gap: 1.5rem; background: #1a1a1a; padding: 1.5rem; border-radius: 5px; border-left: 4px solid #00ff00;">
+<div class="team-member" style="display: flex; gap: 1.5rem; background: var(--aiv-legacy-charcoal); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-legacy-green);">
   <div class="member-photo" style="flex-shrink: 0;">
     {volunteer.data.profile ? (
       <img
         src={`/assets/images/profiles/${volunteer.data.profile}`}
         alt={fullName}
-        style="width: 120px; height: 120px; border-radius: 50%; object-fit: cover; border: 2px solid #00ff00;"
+        style="width: 120px; height: 120px; border-radius: 50%; object-fit: cover; border: 2px solid var(--aiv-legacy-green);"
       />
     ) : (
-      <div style="width: 120px; height: 120px; border-radius: 50%; background: #333; display: flex; align-items: center; justify-content: center; border: 2px solid #00ff00;">
-        <span style="color: #00ff00; font-size: 2rem; font-family: 'JetBrains Mono', monospace;">{initials}</span>
+      <div style="width: 120px; height: 120px; border-radius: 50%; background: var(--aiv-legacy-divider); display: flex; align-items: center; justify-content: center; border: 2px solid var(--aiv-legacy-green);">
+        <span style="color: var(--aiv-legacy-green); font-size: 2rem; font-family: var(--aiv-font-mono);">{initials}</span>
       </div>
     )}
   </div>
   <div class="member-info" style="flex: 1;">
-    <h3 style="margin: 0 0 0.5rem 0; color: #00ff00;">{fullName}</h3>
-    {volunteer.data.position && <div style="color: #ffff00; font-family: 'JetBrains Mono', monospace; font-size: 0.9rem; margin: 0.25rem 0;"><strong>{volunteer.data.position}</strong></div>}
-    {volunteer.data.affiliation && <div style="color: #888; font-size: 0.9rem; margin: 0.25rem 0;"><strong>Affiliation:</strong> {volunteer.data.affiliation}</div>}
-    {volunteer.data.expertise && <div style="color: #888; font-size: 0.9rem; margin: 0.25rem 0;"><strong>Expertise:</strong> {volunteer.data.expertise}</div>}
-    {volunteer.data.bio && Content && <div style="margin-top: 1rem; color: #ccc; line-height: 1.6;"><Content /></div>}
+    <h3 style="margin: 0 0 0.5rem 0; color: var(--aiv-legacy-green);">{fullName}</h3>
+    {volunteer.data.position && <div style="color: var(--aiv-warning); font-family: var(--aiv-font-mono); font-size: 0.9rem; margin: 0.25rem 0;"><strong>{volunteer.data.position}</strong></div>}
+    {volunteer.data.affiliation && <div style="color: var(--aiv-legacy-gray); font-size: 0.9rem; margin: 0.25rem 0;"><strong>Affiliation:</strong> {volunteer.data.affiliation}</div>}
+    {volunteer.data.expertise && <div style="color: var(--aiv-legacy-gray); font-size: 0.9rem; margin: 0.25rem 0;"><strong>Expertise:</strong> {volunteer.data.expertise}</div>}
+    {volunteer.data.bio && Content && <div style="margin-top: 1rem; color: var(--aiv-legacy-light-text); line-height: 1.6;"><Content /></div>}
   </div>
 </div>

--- a/src/layouts/EventLayout.astro
+++ b/src/layouts/EventLayout.astro
@@ -19,12 +19,12 @@ const scheduleLinks = scheduleRoutesForEvent(event.id);
 <BaseLayout title={event.data.title} description={event.data.description} canonical={url} type="event" eventDate={event.data.date} eventLocation={event.data.location}>
   <article class="event">
     <header class="event-header" style="margin-bottom: 2rem;">
-      <h1 style="color: #00ff00; margin: 0 0 1rem 0;">{event.data.title}</h1>
-      <div class="event-meta" style="display: flex; flex-wrap: wrap; gap: 2rem; margin: 1rem 0; color: #888; font-family: 'JetBrains Mono', monospace;">
-        <div><strong style="color: #ffff00;">📅 Date:</strong> <time datetime={isoDate(event.data.date)}>{formatDate(event.data.date)}</time></div>
-        {event.data.location && <div><strong style="color: #ffff00;">📍 Location:</strong> {event.data.location}</div>}
+      <h1 style="color: var(--aiv-legacy-green); margin: 0 0 1rem 0;">{event.data.title}</h1>
+      <div class="event-meta" style="display: flex; flex-wrap: wrap; gap: 2rem; margin: 1rem 0; color: var(--aiv-legacy-gray); font-family: var(--aiv-font-mono);">
+        <div><strong style="color: var(--aiv-warning);">📅 Date:</strong> <time datetime={isoDate(event.data.date)}>{formatDate(event.data.date)}</time></div>
+        {event.data.location && <div><strong style="color: var(--aiv-warning);">📍 Location:</strong> {event.data.location}</div>}
       </div>
-      {event.data.description && <div class="event-description" style="background: #1a1a1a; padding: 1rem; border-left: 4px solid #ff0000; border-radius: 0 5px 5px 0; margin: 1rem 0;"><p style="margin: 0; color: #ccc; font-size: 1.1rem;">{event.data.description}</p></div>}
+      {event.data.description && <div class="event-description" style="background: var(--aiv-legacy-charcoal); padding: 1rem; border-left: 4px solid var(--aiv-risk); border-radius: 0 5px 5px 0; margin: 1rem 0;"><p style="margin: 0; color: var(--aiv-legacy-light-text); font-size: 1.1rem;">{event.data.description}</p></div>}
     </header>
     <div class="event-content" style="line-height: 1.7;">
       <Content />
@@ -37,22 +37,22 @@ const scheduleLinks = scheduleRoutesForEvent(event.id);
         </ul>
       </section>
     )}
-    <footer class="event-footer" style="margin-top: 3rem; padding-top: 2rem; border-top: 1px solid #333;">
-      <div style="text-align: center; margin: 2rem 0; padding: 1.5rem; background: #1a1a1a; border-radius: 5px;">
-        <p style="margin: 0 0 1rem 0; color: #00ff00; font-weight: bold;">🎪 Interested in attending or presenting at AI Village events?</p>
+    <footer class="event-footer" style="margin-top: 3rem; padding-top: 2rem; border-top: 1px solid var(--aiv-legacy-divider);">
+      <div style="text-align: center; margin: 2rem 0; padding: 1.5rem; background: var(--aiv-legacy-charcoal); border-radius: 5px;">
+        <p style="margin: 0 0 1rem 0; color: var(--aiv-legacy-green); font-weight: bold;">🎪 Interested in attending or presenting at AI Village events?</p>
         <div style="display: flex; justify-content: center; gap: 1rem; flex-wrap: wrap;">
-          <a href="/discord/" style="color: #00ffff;">Join our Discord</a>
-          <span style="color: #666;">•</span>
-          <a href="https://forms.gle/vCrz3zpR8xHCsTtJ8" target="_blank" style="color: #00ffff;">Volunteer Application</a>
-          <span style="color: #666;">•</span>
-          <a href="/events/" style="color: #00ffff;">All Events</a>
+          <a href="/discord/" style="color: var(--aiv-action-primary);">Join our Discord</a>
+          <span style="color: var(--aiv-legacy-dim);">•</span>
+          <a href="https://forms.gle/vCrz3zpR8xHCsTtJ8" target="_blank" style="color: var(--aiv-action-primary);">Volunteer Application</a>
+          <span style="color: var(--aiv-legacy-dim);">•</span>
+          <a href="/events/" style="color: var(--aiv-action-primary);">All Events</a>
         </div>
       </div>
       <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; margin-top: 2rem;">
         <div class="event-navigation">
-          {previous && <a href={eventPath(previous)} style="color: #00ffff;">← {truncate(previous.data.title, 30)}</a>}
-          {previous && next && <span style="color: #666; margin: 0 1rem;">|</span>}
-          {next && <a href={eventPath(next)} style="color: #00ffff;">{truncate(next.data.title, 30)} →</a>}
+          {previous && <a href={eventPath(previous)} style="color: var(--aiv-action-primary);">← {truncate(previous.data.title, 30)}</a>}
+          {previous && next && <span style="color: var(--aiv-legacy-dim); margin: 0 1rem;">|</span>}
+          {next && <a href={eventPath(next)} style="color: var(--aiv-action-primary);">{truncate(next.data.title, 30)} →</a>}
         </div>
         <div class="event-share">
           <a href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(event.data.title)}&via=aivillage_dc`} target="_blank" style="color: #1DA1F2; margin: 0 0.5rem;">Share Event</a>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,7 +5,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 <BaseLayout title="404" canonical="/404.html">
   <div class="card" style="text-align: center;">
     <h1>404</h1>
-    <p style="color: #888;">Page not found.</p>
-    <p><a href="/" style="color: #00ffff;">Return home</a></p>
+    <p style="color: var(--aiv-legacy-gray);">Page not found.</p>
+    <p><a href="/" style="color: var(--aiv-action-primary);">Return home</a></p>
   </div>
 </BaseLayout>

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -16,7 +16,7 @@ for (const volunteer of volunteers) {
 <BaseLayout title="About" canonical="/about/">
   <h1>About AI Village</h1>
   <div style="text-align: center; margin: 2rem 0;">
-    <p style="color: #888; font-size: 1.1rem;">
+    <p style="color: var(--aiv-legacy-gray); font-size: 1.1rem;">
       AI Village is a community of hackers and data scientists working to educate the world on the use and abuse of artificial intelligence in security and privacy.
     </p>
   </div>
@@ -39,18 +39,18 @@ for (const volunteer of volunteers) {
       return (
         <>
           <VolunteerCard volunteer={volunteer} Content={Content} />
-          {index < volunteers.length - 1 && <hr style="border: none; border-top: 1px solid #333; margin: 1rem 0;" />}
+          {index < volunteers.length - 1 && <hr style="border: none; border-top: 1px solid var(--aiv-legacy-divider); margin: 1rem 0;" />}
         </>
       );
     })}
   </div>
   <hr />
   <h2 id="-join-our-team">Join the Work</h2>
-  <div style="background: #1a1a1a; padding: 1.5rem; border-radius: 5px; border-left: 4px solid #ff0000; margin: 2rem 0;">
-    <h4 style="color: #ff0000; margin-top: 0;">Get Involved</h4>
+  <div style="background: var(--aiv-legacy-charcoal); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-risk); margin: 2rem 0;">
+    <h4 style="color: var(--aiv-risk); margin-top: 0;">Get Involved</h4>
     <p>AI Village welcomes help from researchers, engineers, educators, organizers, and community builders.</p>
     <div style="margin-top: 1.5rem;">
-      <a href="https://forms.gle/vCrz3zpR8xHCsTtJ8" target="_blank" rel="noopener noreferrer" style="color: #00ffff; font-weight: bold;">→ Submit a volunteer application</a>
+      <a href="https://forms.gle/vCrz3zpR8xHCsTtJ8" target="_blank" rel="noopener noreferrer" style="color: var(--aiv-action-primary); font-weight: bold;">→ Submit a volunteer application</a>
     </div>
   </div>
 </BaseLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -10,7 +10,7 @@ const posts = sortPosts(await getCollection("blog", ({ data }) => !data.draft));
 <BaseLayout title="Blog" canonical="/blog/">
   <h1>Blog</h1>
   <div style="text-align: center; margin: 2rem 0;">
-    <p style="color: #888; font-size: 1.1rem;">
+    <p style="color: var(--aiv-legacy-gray); font-size: 1.1rem;">
       Research insights, event recaps, and perspectives on AI security from our community.
     </p>
   </div>
@@ -18,10 +18,10 @@ const posts = sortPosts(await getCollection("blog", ({ data }) => !data.draft));
   <div class="post-list">
     {posts.map((post) => <PostCard post={post} />)}
   </div>
-  {posts.length === 0 && <div class="card" style="text-align: center;"><h3 style="color: #888;">No blog posts yet</h3><p style="color: #666;">Check back soon for updates from the AI Village community!</p></div>}
+  {posts.length === 0 && <div class="card" style="text-align: center;"><h3 style="color: var(--aiv-legacy-gray);">No blog posts yet</h3><p style="color: var(--aiv-legacy-dim);">Check back soon for updates from the AI Village community!</p></div>}
   <hr />
-  <div style="background: #1a1a1a; padding: 1.5rem; border-radius: 5px; border-left: 4px solid #00ff00; margin: 2rem 0;">
-    <h4 style="color: #00ff00; margin-top: 0;">📝 Want to Contribute?</h4>
+  <div style="background: var(--aiv-legacy-charcoal); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-legacy-green); margin: 2rem 0;">
+    <h4 style="color: var(--aiv-legacy-green); margin-top: 0;">📝 Want to Contribute?</h4>
     <p>We welcome guest posts from the community! Topics we're interested in:</p>
     <ul>
       <li>AI security research and findings</li>
@@ -31,7 +31,7 @@ const posts = sortPosts(await getCollection("blog", ({ data }) => !data.draft));
       <li>Technical deep dives and case studies</li>
     </ul>
     <p>
-      <a href="https://github.com/aivillage/aiv_website" target="_blank" style="color: #00ffff;">Submit a pull request →</a>
+      <a href="https://github.com/aivillage/aiv_website" target="_blank" style="color: var(--aiv-action-primary);">Submit a pull request →</a>
       or reach out on Discord to discuss your ideas.
     </p>
   </div>

--- a/src/pages/community/index.astro
+++ b/src/pages/community/index.astro
@@ -55,7 +55,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
     </div>
   </section>
 
-  <div class="card" style="border-left: 4px solid #ff0000; margin-top: 2.5rem;">
+  <div class="card" style="border-left: 4px solid var(--aiv-risk); margin-top: 2.5rem;">
     <h2 style="margin-top: 0;">Before Participating</h2>
     <p style="margin-bottom: 0;">
       Read the <a href="/about/conduct/">code of conduct</a> and help keep AI Village welcoming for participants, speakers, sponsors, and volunteers.

--- a/src/pages/discord/index.astro
+++ b/src/pages/discord/index.astro
@@ -5,16 +5,16 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 <BaseLayout title="Discord Community" canonical="/discord/">
   <h1>Discord Community</h1>
   <div style="text-align: center; margin: 2rem 0;">
-    <h2 style="color: #00ff00;">Join the AI Village Discord</h2>
-    <p style="color: #888; font-size: 1.1rem;">Connect with researchers, hackers, and AI security enthusiasts from around the world.</p>
+    <h2 style="color: var(--aiv-legacy-green);">Join the AI Village Discord</h2>
+    <p style="color: var(--aiv-legacy-gray); font-size: 1.1rem;">Connect with researchers, hackers, and AI security enthusiasts from around the world.</p>
     <div style="margin: 2rem 0;">
-      <a href="https://discord.com/invite/GX5fhfT" target="_blank" style="background: #5865F2; color: white; padding: 1rem 2rem; border-radius: 5px; text-decoration: none; font-weight: bold; font-size: 1.1rem;">🎮 Join Discord Server</a>
+      <a href="https://discord.com/invite/GX5fhfT" target="_blank" style="background: #5865F2; color: var(--aiv-text-primary); padding: 1rem 2rem; border-radius: 5px; text-decoration: none; font-weight: bold; font-size: 1.1rem;">🎮 Join Discord Server</a>
     </div>
   </div>
   <hr />
   <h2>🚀 Getting Started</h2>
-  <div class="card" style="background: #1a1a1a; border-left: 4px solid #00ff00;">
-    <h3 style="color: #00ff00; margin-top: 0;">📝 First Steps</h3>
+  <div class="card" style="background: var(--aiv-legacy-charcoal); border-left: 4px solid var(--aiv-legacy-green);">
+    <h3 style="color: var(--aiv-legacy-green); margin-top: 0;">📝 First Steps</h3>
     <ol style="line-height: 1.8;">
       <li><strong>Join the server</strong> using the link above</li>
       <li><strong>Introduce yourself</strong> in the <code>#start-here</code> channel</li>
@@ -22,47 +22,47 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
       <li><strong>Explore channels</strong> and find your interests</li>
       <li><strong>Participate</strong> in discussions and events</li>
     </ol>
-    <div style="background: #333; padding: 1rem; border-radius: 5px; margin: 1rem 0;">
+    <div style="background: var(--aiv-legacy-divider); padding: 1rem; border-radius: 5px; margin: 1rem 0;">
       <p style="margin: 0;"><strong>⚠️ Important:</strong> When you first join, you'll only have access to <code>#start-here</code>. Drop a note introducing yourself, and someone will give you the "Villager" role for full access!</p>
     </div>
   </div>
   <hr />
   <h2>📋 Community Guidelines</h2>
   <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem; margin: 2rem 0;">
-    <div class="card"><h4 style="color: #ff0000; margin-top: 0;">🚫 Basic Rules</h4><ul style="margin: 0.5rem 0; line-height: 1.6;"><li>Stay on topic in specialized channels</li><li>No NSFW content permitted</li><li>No illegal behavior or solicitation</li><li>No spamming or channel disruption</li><li>Follow the AI Village <a href="/about/conduct/">Code of Conduct</a></li></ul></div>
-    <div class="card"><h4 style="color: #ffff00; margin-top: 0;">💬 Communication</h4><ul style="margin: 0.5rem 0; line-height: 1.6;"><li>Use threads for long discussions</li><li>Take off-topic conversations to #general</li><li>Be respectful and constructive</li><li>Help newcomers get oriented</li><li>Share knowledge and resources</li></ul></div>
+    <div class="card"><h4 style="color: var(--aiv-risk); margin-top: 0;">🚫 Basic Rules</h4><ul style="margin: 0.5rem 0; line-height: 1.6;"><li>Stay on topic in specialized channels</li><li>No NSFW content permitted</li><li>No illegal behavior or solicitation</li><li>No spamming or channel disruption</li><li>Follow the AI Village <a href="/about/conduct/">Code of Conduct</a></li></ul></div>
+    <div class="card"><h4 style="color: var(--aiv-warning); margin-top: 0;">💬 Communication</h4><ul style="margin: 0.5rem 0; line-height: 1.6;"><li>Use threads for long discussions</li><li>Take off-topic conversations to #general</li><li>Be respectful and constructive</li><li>Help newcomers get oriented</li><li>Share knowledge and resources</li></ul></div>
   </div>
   <hr />
   <h2>🏆 Community Roles</h2>
   <div class="role-hierarchy" style="margin: 2rem 0;">
-    <div class="role-card" style="background: #1a1a1a; padding: 1rem; margin: 1rem 0; border-left: 4px solid #888; border-radius: 0 5px 5px 0;"><h4 style="color: #888; margin: 0 0 0.5rem 0;">👤 Villager</h4><p style="margin: 0; color: #ccc;">Basic member role with access to most channels. Granted after introduction in #start-here.</p></div>
-    <div class="role-card" style="background: #1a1a1a; padding: 1rem; margin: 1rem 0; border-left: 4px solid #00ff00; border-radius: 0 5px 5px 0;"><h4 style="color: #00ff00; margin: 0 0 0.5rem 0;">⭐ ElderVillager</h4><p style="margin: 0; color: #ccc;">Active community members who have contributed talks, workshops, or sustained participation. Can invite new members and promote to Villager role.</p></div>
-    <div class="role-card" style="background: #1a1a1a; padding: 1rem; margin: 1rem 0; border-left: 4px solid #ffff00; border-radius: 0 5px 5px 0;"><h4 style="color: #ffff00; margin: 0 0 0.5rem 0;">🛡️ Officer</h4><p style="margin: 0; color: #ccc;">Community leaders who have organized substantial events or content. Have moderation powers and can help establish new initiatives.</p></div>
-    <div class="role-card" style="background: #1a1a1a; padding: 1rem; margin: 1rem 0; border-left: 4px solid #ff0000; border-radius: 0 5px 5px 0;"><h4 style="color: #ff0000; margin: 0 0 0.5rem 0;">👑 Board</h4><p style="margin: 0; color: #ccc;">AI Village board members with full moderation powers. Contact for harassment issues or code of conduct violations.</p></div>
+    <div class="role-card" style="background: var(--aiv-legacy-charcoal); padding: 1rem; margin: 1rem 0; border-left: 4px solid var(--aiv-legacy-gray); border-radius: 0 5px 5px 0;"><h4 style="color: var(--aiv-legacy-gray); margin: 0 0 0.5rem 0;">👤 Villager</h4><p style="margin: 0; color: var(--aiv-legacy-light-text);">Basic member role with access to most channels. Granted after introduction in #start-here.</p></div>
+    <div class="role-card" style="background: var(--aiv-legacy-charcoal); padding: 1rem; margin: 1rem 0; border-left: 4px solid var(--aiv-legacy-green); border-radius: 0 5px 5px 0;"><h4 style="color: var(--aiv-legacy-green); margin: 0 0 0.5rem 0;">⭐ ElderVillager</h4><p style="margin: 0; color: var(--aiv-legacy-light-text);">Active community members who have contributed talks, workshops, or sustained participation. Can invite new members and promote to Villager role.</p></div>
+    <div class="role-card" style="background: var(--aiv-legacy-charcoal); padding: 1rem; margin: 1rem 0; border-left: 4px solid var(--aiv-warning); border-radius: 0 5px 5px 0;"><h4 style="color: var(--aiv-warning); margin: 0 0 0.5rem 0;">🛡️ Officer</h4><p style="margin: 0; color: var(--aiv-legacy-light-text);">Community leaders who have organized substantial events or content. Have moderation powers and can help establish new initiatives.</p></div>
+    <div class="role-card" style="background: var(--aiv-legacy-charcoal); padding: 1rem; margin: 1rem 0; border-left: 4px solid var(--aiv-risk); border-radius: 0 5px 5px 0;"><h4 style="color: var(--aiv-risk); margin: 0 0 0.5rem 0;">👑 Board</h4><p style="margin: 0; color: var(--aiv-legacy-light-text);">AI Village board members with full moderation powers. Contact for harassment issues or code of conduct violations.</p></div>
   </div>
   <hr />
   <h2>🎯 Popular Channels</h2>
   <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1rem; margin: 2rem 0;">
     {["#general:General discussion and off-topic conversations", "#research:AI security research discussions and paper reviews", "#events:Announcements and discussions about upcoming events", "#tools-and-code:Sharing tools, code, and technical resources", "#job-board:AI security job postings and career discussions", "#ctf-discussion:CTF announcements, team formation, and writeups"].map((item) => {
       const [name, text] = item.split(":");
-      return <div class="card"><h4 style="color: #00ff00; margin-top: 0;">{name}</h4><p>{text}</p></div>;
+      return <div class="card"><h4 style="color: var(--aiv-legacy-green); margin-top: 0;">{name}</h4><p>{text}</p></div>;
     })}
   </div>
   <hr />
   <h2>📅 Regular Events</h2>
   <div class="events-grid" style="margin: 2rem 0;">
-    <div class="card" style="text-align: center;"><h4 style="color: #ffff00; margin-top: 0;">📚 Hacker Journal Club</h4><p style="color: #888; font-family: 'JetBrains Mono', monospace;">Wednesdays at 5 PM PST / 8 PM EST</p><p>Discuss academic papers with industry perspective, covering everything from ML security to policy.</p></div>
-    <div class="card" style="text-align: center;"><h4 style="color: #ffff00; margin-top: 0;">🔒 Privacy & Ethics Journal Club</h4><p style="color: #888; font-family: 'JetBrains Mono', monospace;">Tuesdays at 5 PM PST / 8 PM EST</p><p>Interdisciplinary analysis of AI systems from theoretical and practical perspectives.</p></div>
+    <div class="card" style="text-align: center;"><h4 style="color: var(--aiv-warning); margin-top: 0;">📚 Hacker Journal Club</h4><p style="color: var(--aiv-legacy-gray); font-family: var(--aiv-font-mono);">Wednesdays at 5 PM PST / 8 PM EST</p><p>Discuss academic papers with industry perspective, covering everything from ML security to policy.</p></div>
+    <div class="card" style="text-align: center;"><h4 style="color: var(--aiv-warning); margin-top: 0;">🔒 Privacy & Ethics Journal Club</h4><p style="color: var(--aiv-legacy-gray); font-family: var(--aiv-font-mono);">Tuesdays at 5 PM PST / 8 PM EST</p><p>Interdisciplinary analysis of AI systems from theoretical and practical perspectives.</p></div>
   </div>
-  <div style="background: #1a1a1a; padding: 1.5rem; border-radius: 5px; border-left: 4px solid #00ffff; margin: 2rem 0;">
-    <h4 style="color: #00ffff; margin-top: 0;">📅 Event Updates</h4>
+  <div style="background: var(--aiv-legacy-charcoal); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-action-primary); margin: 2rem 0;">
+    <h4 style="color: var(--aiv-action-primary); margin-top: 0;">📅 Event Updates</h4>
     <p>Use the events archive for upcoming AI Village appearances and past schedules.</p>
-    <p style="margin-bottom: 0;"><a href="/events/" style="color: #00ffff; font-weight: bold;">View AI Village events</a></p>
+    <p style="margin-bottom: 0;"><a href="/events/" style="color: var(--aiv-action-primary); font-weight: bold;">View AI Village events</a></p>
   </div>
   <hr />
   <h2>❓ Need Help?</h2>
-  <div style="background: #1a1a1a; padding: 1.5rem; border-radius: 5px; border-left: 4px solid #ff0000;">
-    <h4 style="color: #ff0000; margin-top: 0;">🆘 Support & Issues</h4>
+  <div style="background: var(--aiv-legacy-charcoal); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-risk);">
+    <h4 style="color: var(--aiv-risk); margin-top: 0;">🆘 Support & Issues</h4>
     <p>If you experience harassment or have concerns about community behavior:</p>
     <ul><li><strong>Contact Officers or Board members</strong> directly via DM</li><li><strong>Use the server reporting system</strong> for serious issues</li><li><strong>Remember:</strong> We have zero tolerance for harassment</li></ul>
     <p style="margin-bottom: 0;">Our community is dedicated to providing a safe and welcoming environment for everyone.</p>

--- a/src/pages/grt/index.astro
+++ b/src/pages/grt/index.astro
@@ -22,7 +22,7 @@ const events = (await getCollection("events")).filter((event) => `${event.data.t
     This page keeps the public claims narrow: it links the existing source material and gives visitors a single place to understand the program context without adding unsupported partner, scale, or outcome claims.
   </p>
 
-  <div class="card" style="border-left: 4px solid #00ff00;">
+  <div class="card" style="border-left: 4px solid var(--aiv-legacy-green);">
     <h2 style="margin-top: 0;">Program Threads</h2>
     <ul>
       <li>GRT history and lessons from the DEF CON 31 recap.</li>
@@ -41,7 +41,7 @@ const events = (await getCollection("events")).filter((event) => `${event.data.t
   <h2>Related Events</h2>
   <div class="events-list">{events.map((event) => <EventCard event={event} />)}</div>
 
-  <div class="card" style="border-left: 4px solid #00ffff; margin-top: 2rem;">
+  <div class="card" style="border-left: 4px solid var(--aiv-action-primary); margin-top: 2rem;">
     <h2 style="margin-top: 0;">Get Involved</h2>
     <p>
       For current participation details, use the public event pages and join the <a href="/discord/">AI Village Discord</a>.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ const latestPost = posts[0];
 <BaseLayout title="Home" canonical="/">
   <div style="text-align: center; margin: 3rem 0;">
     <h1 class="glitch cursor" data-text="AI VILLAGE">AI VILLAGE</h1>
-    <p style="font-size: 1.2rem; color: #888; font-family: 'JetBrains Mono', monospace;">
+    <p style="font-size: 1.2rem; color: var(--aiv-legacy-gray); font-family: var(--aiv-font-mono);">
       A community of hackers and data scientists working to educate the world on the use and abuse of artificial intelligence in security and privacy.
     </p>
   </div>
@@ -33,9 +33,9 @@ const latestPost = posts[0];
     </style>
 
     <div class="card">
-      <h3 style="color: #00ff00; margin-top: 0;">🔥 Upcoming Events</h3>
+      <h3 style="color: var(--aiv-legacy-green); margin-top: 0;">🔥 Upcoming Events</h3>
       {upcomingEvent ? (
-        <div class="event-item" style="background: #1a1a1a; border-left: 4px solid #ff0000;">
+        <div class="event-item" style="background: var(--aiv-legacy-charcoal); border-left: 4px solid var(--aiv-risk);">
           <DateBadge date={upcomingEvent.data.date} />
           <div class="event-content">
             <h4 style="margin: 0;"><a href={eventPath(upcomingEvent)}>{upcomingEvent.data.title}</a></h4>
@@ -44,25 +44,25 @@ const latestPost = posts[0];
           </div>
         </div>
       ) : (
-        <p style="color: #888;">No upcoming events at this time.</p>
+        <p style="color: var(--aiv-legacy-gray);">No upcoming events at this time.</p>
       )}
-      <p style="margin-top: 1rem;"><a href="/events/" style="color: #00ffff;">→ View all events</a></p>
+      <p style="margin-top: 1rem;"><a href="/events/" style="color: var(--aiv-action-primary);">→ View all events</a></p>
     </div>
 
     <div class="card">
-      <h3 style="color: #00ff00; margin-top: 0;">📝 Latest Blog Post</h3>
+      <h3 style="color: var(--aiv-legacy-green); margin-top: 0;">📝 Latest Blog Post</h3>
       {latestPost ? (
         <>
           <h4 style="margin: 0.5rem 0;"><a href={canonicalPostPath(latestPost)}>{latestPost.data.title}</a></h4>
-          <div style="color: #888; font-size: 0.9rem; font-family: 'JetBrains Mono', monospace; margin: 0.5rem 0;">
+          <div style="color: var(--aiv-legacy-gray); font-size: 0.9rem; font-family: var(--aiv-font-mono); margin: 0.5rem 0;">
             By {Array.isArray(latestPost.data.author) ? latestPost.data.author.join(", ") : latestPost.data.author} • {formatShortDate(latestPost.data.date)}
           </div>
           <div style="margin: 1rem 0;">{latestPost.data.description ?? excerptFromBody(latestPost.body ?? "", 20)}</div>
         </>
       ) : (
-        <p style="color: #888;">No blog posts yet.</p>
+        <p style="color: var(--aiv-legacy-gray);">No blog posts yet.</p>
       )}
-      <p style="margin-top: 1rem;"><a href="/blog/" style="color: #00ffff;">→ Read all posts</a></p>
+      <p style="margin-top: 1rem;"><a href="/blog/" style="color: var(--aiv-action-primary);">→ Read all posts</a></p>
     </div>
   </div>
 
@@ -73,15 +73,15 @@ const latestPost = posts[0];
 
   <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.5rem; margin: 2rem 0;">
     <div class="card" style="text-align: center;">
-      <h4 style="color: #ffff00;">🛡️ Security Research</h4>
+      <h4 style="color: var(--aiv-warning);">🛡️ Security Research</h4>
       <p>Exploring vulnerabilities and defenses in AI systems through hands-on research and experimentation.</p>
     </div>
     <div class="card" style="text-align: center;">
-      <h4 style="color: #ffff00;">🎓 Education</h4>
+      <h4 style="color: var(--aiv-warning);">🎓 Education</h4>
       <p>Teaching the security community about AI risks and the AI community about security practices.</p>
     </div>
     <div class="card" style="text-align: center;">
-      <h4 style="color: #ffff00;">🤝 Community</h4>
+      <h4 style="color: var(--aiv-warning);">🤝 Community</h4>
       <p>Building bridges between hackers, data scientists, researchers, and policy makers.</p>
     </div>
   </div>
@@ -109,7 +109,7 @@ const latestPost = posts[0];
         <p>
           AI Village is supported by volunteers, researchers, builders, and organizations that contribute to AI security education and research.
         </p>
-        <p><a href="/sponsors/" style="color: #00ffff;">Sponsor AI Village →</a></p>
+        <p><a href="/sponsors/" style="color: var(--aiv-action-primary);">Sponsor AI Village →</a></p>
       </section>
     </>
   )}
@@ -117,7 +117,7 @@ const latestPost = posts[0];
   <hr />
 
   <h2 id="-get-involved">🚀 Get Involved</h2>
-  <div style="background: #1a1a1a; padding: 1.5rem; border-radius: 5px; border-left: 4px solid #00ff00;">
+  <div style="background: var(--aiv-legacy-charcoal); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-legacy-green);">
     <p><strong>Want to join our community?</strong></p>
     <ul>
       <li><a href="https://discord.com/invite/GX5fhfT">Join our Discord</a> - Chat with fellow researchers and stay updated</li>

--- a/src/pages/learn/index.astro
+++ b/src/pages/learn/index.astro
@@ -34,15 +34,15 @@ const additionalWorkshopDirectories = [
     This is not a complete curriculum. It is a clear entry point into the open workshop infrastructure that already exists and can grow into more structured learning paths.
   </p>
 
-  <div class="card" style="border-left: 4px solid #00ff00;">
+  <div class="card" style="border-left: 4px solid var(--aiv-legacy-green);">
     <h2 style="margin-top: 0;">Workshop Philosophy</h2>
-    <blockquote style="color: #ccc; font-size: 1.2rem; margin: 1rem 0;">
+    <blockquote style="color: var(--aiv-text-secondary); font-size: 1.2rem; margin: 1rem 0;">
       "get them excited to learn"
     </blockquote>
     <p>
       AIV's workshop philosophy is not that every participant masters the skill in the room. The goal is to make the topic accessible, spark interest, and give people a path to continue learning.
     </p>
-    <p style="color: #888; font-size: 0.95rem;">Source: AIV Workshops contributor guidelines.</p>
+    <p style="color: var(--aiv-legacy-gray); font-size: 0.95rem;">Source: AIV Workshops contributor guidelines.</p>
   </div>
 
   <hr />
@@ -56,7 +56,7 @@ const additionalWorkshopDirectories = [
       </article>
     ))}
   </div>
-  <p style="color: #888;">
+  <p style="color: var(--aiv-legacy-gray);">
     Additional workshop directories in the public repository:
     {additionalWorkshopDirectories.map((workshop, index) => (
       <>
@@ -82,7 +82,7 @@ const additionalWorkshopDirectories = [
     AI Village event pages include talks, demos, and workshops where that information is available in current site content. Start with the <a href="/events/">events archive</a> and join the <a href="/discord/">Discord</a> for community discussion.
   </p>
 
-  <div class="card" style="border-left: 4px solid #00ffff;">
+  <div class="card" style="border-left: 4px solid var(--aiv-action-primary);">
     <h2 style="margin-top: 0;">Contribute</h2>
     <p>
       Workshop contributions should be self-contained containers connected by `docker-compose.yml` and serving a single website. Review the public workshop repository before proposing new material.

--- a/src/styles/_events.scss
+++ b/src/styles/_events.scss
@@ -2,19 +2,19 @@
 
 /* Ensure event items use dark theme consistently */
 .event-item {
-  background: rgba(26, 0, 41, 0.6) !important;
+  background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent) !important;
   backdrop-filter: blur(20px) !important;
-  border: 1px solid rgba(138, 43, 226, 0.4) !important;
+  border: 1px solid color-mix(in srgb, var(--aiv-decoration-violet) 40%, transparent) !important;
 }
 
 .event-date {
-  background-color: #2a0040 !important;
-  color: #00ffff !important;
+  background-color: var(--aiv-bg-panel) !important;
+  color: var(--aiv-action-primary) !important;
 }
 
 .future-events .event-description,
 .past-events .event-description {
-  color: #e6e6fa !important;
+  color: var(--aiv-text-secondary) !important;
 }
 
 /* === Event Content === */
@@ -33,7 +33,7 @@
   padding: 0;
   font-style: italic;
   font-size: 0.75rem;
-  color: #6c757d;
+  color: var(--aiv-legacy-bootstrap-muted);
   margin-top: 0.25rem;
 }
 
@@ -47,10 +47,10 @@
   font-size: 1.2rem;
   margin-top: 1rem;
   margin-bottom: 1.5rem;
-  color: #00ffff !important;
-  background: rgba(42, 0, 64, 0.8) !important;
+  color: var(--aiv-action-primary) !important;
+  background: color-mix(in srgb, var(--aiv-bg-panel) 80%, transparent) !important;
   backdrop-filter: blur(20px);
-  border: 1px solid rgba(138, 43, 226, 0.4);
+  border: 1px solid color-mix(in srgb, var(--aiv-decoration-violet) 40%, transparent);
   padding: 0.5rem 1rem;
   border-radius: 6px;
   display: block;
@@ -77,7 +77,7 @@
   transform-origin: 50% 50%;
   transition: transform 0.3s ease;
   font-size: 1rem;
-  color: #00ffff !important;
+  color: var(--aiv-action-primary) !important;
 }
 
 /* Rotate arrow when open */
@@ -103,9 +103,9 @@ details[open]>.events-container {
   font-size: 1.3rem;
   margin-bottom: 0.85rem;
   font-weight: bold;
-  border-bottom: 1px solid rgba(0, 255, 255, 0.45);
+  border-bottom: 1px solid color-mix(in srgb, var(--aiv-action-primary) 45%, transparent);
   padding-bottom: 0.4rem;
-  color: #00ff00;
+  color: var(--aiv-legacy-green);
 }
 
 /* === Mobile Layout Adjustments === */
@@ -150,5 +150,5 @@ details[open]>.events-container {
   font-size: 1.4rem;
   margin-bottom: 1rem;
   margin-top: 1rem;
-  color: #00ffff !important;
+  color: var(--aiv-action-primary) !important;
 }

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,62 +1,112 @@
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&family=Inter:wght@300;400;500;600;700&display=swap');
 
 /* ===================================
-   VAPORWAVE PROFESSIONAL VARIABLES
+   DESIGN TOKENS
    =================================== */
 
 :root {
-  /* Vaporwave Professional Palette */
-  --bg-primary: #0a0014;
-  --bg-secondary: #1a0029;
-  --bg-tertiary: #2a0040;
-  --bg-glass: rgba(138, 43, 226, 0.1);
+  color-scheme: dark;
 
-  /* Neon accents */
-  --neon-cyan: #00ffff;
-  --neon-magenta: #ff00ff;
-  --neon-purple: #8a2be2;
-  --neon-pink: #ff1493;
-  --neon-blue: #4169e1;
+  --aiv-bg-canvas: #0a0014;
+  --aiv-bg-surface: #1a0029;
+  --aiv-bg-panel: #2a0040;
+  --aiv-bg-raised: #2a0040;
+  --aiv-line-subtle: rgba(138, 43, 226, 0.4);
+  --aiv-line-strong: rgba(0, 255, 255, 0.6);
+  --aiv-grid-color: rgba(0, 255, 255, 0.2);
 
-  /* Professional text colors */
-  --text-primary: #ffffff;
-  --text-secondary: #e6e6fa;
-  --text-accent: #00ffff;
-  --text-muted: #b19cd9;
+  --aiv-text-primary: #ffffff;
+  --aiv-text-secondary: #e6e6fa;
+  --aiv-text-muted: #b19cd9;
 
-  /* Grid and borders */
-  --grid-color: rgba(0, 255, 255, 0.2);
-  --border-primary: rgba(138, 43, 226, 0.4);
-  --border-accent: rgba(0, 255, 255, 0.6);
+  --aiv-action-primary: #00ffff;
+  --aiv-action-secondary: #ff00ff;
+  --aiv-warning: #ffff00;
+  --aiv-risk: #ff0000;
 
-  /* Fonts */
-  --font-mono: 'JetBrains Mono', monospace;
-  --font-sans: 'Inter', sans-serif;
+  --aiv-decoration-violet: #8a2be2;
+
+  --aiv-legacy-cyan: #00ffff;
+  --aiv-legacy-magenta: #ff00ff;
+  --aiv-legacy-green: #00ff00;
+  --aiv-legacy-yellow: #ffff00;
+  --aiv-legacy-red: #ff0000;
+  --aiv-legacy-charcoal: #1a1a1a;
+  --aiv-legacy-divider: #333333;
+  --aiv-legacy-bootstrap-muted: #6c757d;
+  --aiv-legacy-gray: #888888;
+  --aiv-legacy-dim: #666666;
+  --aiv-legacy-light-text: #cccccc;
+  --aiv-legacy-glass: rgba(138, 43, 226, 0.1);
+
+  --aiv-font-body: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --aiv-font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
 }
 
-// SCSS Variables for easier use
-$bg-primary: #0a0014;
-$bg-secondary: #1a0029;
-$bg-tertiary: #2a0040;
-$bg-glass: rgba(138, 43, 226, 0.1);
+.theme-institutional-next {
+  color-scheme: dark;
 
-$neon-cyan: #00ffff;
-$neon-magenta: #ff00ff;
-$neon-purple: #8a2be2;
-$neon-pink: #ff1493;
-$neon-blue: #4169e1;
+  --aiv-bg-canvas: #0B0D0E;
+  --aiv-bg-surface: #11161A;
+  --aiv-bg-panel: #182027;
+  --aiv-bg-raised: #202A32;
+  --aiv-line-subtle: #2A343D;
+  --aiv-line-strong: #3A4652;
+  --aiv-grid-color: rgba(155, 200, 165, 0.14);
 
-$text-primary: #ffffff;
-$text-secondary: #e6e6fa;
-$text-accent: #00ffff;
-$text-muted: #b19cd9;
+  --aiv-text-primary: #F4F1E8;
+  --aiv-text-secondary: #C7D0D9;
+  --aiv-text-muted: #8A96A3;
 
-$grid-color: rgba(0, 255, 255, 0.2);
-$border-primary: rgba(138, 43, 226, 0.4);
-$border-accent: rgba(0, 255, 255, 0.6);
+  --aiv-action-primary: #9BC8A5;
+  --aiv-action-secondary: #6EA8D9;
+  --aiv-warning: #D99A2B;
+  --aiv-risk: #E05F50;
 
-$font-mono: 'JetBrains Mono', monospace;
-$font-sans: 'Inter', sans-serif;
+  --aiv-decoration-violet: #8B5CF6;
+}
+
+.theme-light,
+.theme-print {
+  color-scheme: light;
+
+  --aiv-bg-canvas: #F7F3EA;
+  --aiv-bg-surface: #FFFFFF;
+  --aiv-bg-panel: #ECE6DA;
+  --aiv-bg-raised: #E2D8C8;
+  --aiv-line-subtle: #C9BFAF;
+  --aiv-line-strong: #9E9384;
+  --aiv-grid-color: rgba(39, 92, 69, 0.12);
+
+  --aiv-text-primary: #121619;
+  --aiv-text-secondary: #33404A;
+  --aiv-text-muted: #52606A;
+
+  --aiv-action-primary: #275C45;
+  --aiv-action-secondary: #24547A;
+  --aiv-warning: #87560A;
+  --aiv-risk: #9B302B;
+
+  --aiv-decoration-violet: #5B3AA1;
+
+  --aiv-legacy-cyan: #007A86;
+  --aiv-legacy-magenta: #9B1A8E;
+  --aiv-legacy-green: #007a2f;
+  --aiv-legacy-yellow: #87560A;
+  --aiv-legacy-red: #9B302B;
+  --aiv-legacy-charcoal: #FFFFFF;
+  --aiv-legacy-divider: #C9BFAF;
+  --aiv-legacy-bootstrap-muted: #52606A;
+  --aiv-legacy-gray: #52606A;
+  --aiv-legacy-dim: #6B7280;
+  --aiv-legacy-light-text: #33404A;
+  --aiv-legacy-glass: rgba(91, 58, 161, 0.1);
+}
+
+.theme-event {
+  --aiv-action-primary: var(--aiv-legacy-cyan);
+  --aiv-action-secondary: var(--aiv-legacy-magenta);
+}
 
 /* ===================================
    RESET AND BASE STYLES
@@ -79,11 +129,11 @@ html {
 }
 
 body {
-  font-family: $font-sans;
-  background: linear-gradient(135deg, #0a0014 0%, #1a0029 50%, #2a0040 100%) !important;
-  background-color: #0a0014 !important;
+  font-family: var(--aiv-font-body);
+  background: linear-gradient(135deg, var(--aiv-bg-canvas) 0%, var(--aiv-bg-surface) 50%, var(--aiv-bg-panel) 100%) !important;
+  background-color: var(--aiv-bg-canvas) !important;
   background-attachment: fixed !important;
-  color: $text-primary;
+  color: var(--aiv-text-primary);
   line-height: 1.6;
   margin: 0;
   padding: 0;
@@ -93,8 +143,8 @@ body {
 }
 
 html {
-  background: #0a0014 !important;
-  background-color: #0a0014 !important;
+  background: var(--aiv-bg-canvas) !important;
+  background-color: var(--aiv-bg-canvas) !important;
 }
 
 // Ensure all main containers inherit the dark background
@@ -118,8 +168,8 @@ body::before {
   width: 100%;
   height: 100%;
   background-image:
-    linear-gradient($grid-color 1px, transparent 1px),
-    linear-gradient(90deg, $grid-color 1px, transparent 1px);
+    linear-gradient(var(--aiv-grid-color) 1px, transparent 1px),
+    linear-gradient(90deg, var(--aiv-grid-color) 1px, transparent 1px);
   background-size: 50px 50px;
   animation: gridMove 20s linear infinite;
   pointer-events: none;
@@ -144,7 +194,7 @@ body::after {
   left: 0;
   width: 100%;
   height: 100%;
-  background: radial-gradient(ellipse at center, rgba(138, 43, 226, 0.1) 0%, transparent 70%);
+  background: radial-gradient(ellipse at center, color-mix(in srgb, var(--aiv-decoration-violet) 10%, transparent) 0%, transparent 70%);
   pointer-events: none;
   z-index: -1;
 }
@@ -159,8 +209,8 @@ h3,
 h4,
 h5,
 h6 {
-  color: $text-accent;
-  font-family: $font-mono;
+  color: var(--aiv-action-primary);
+  font-family: var(--aiv-font-mono);
   margin: 1.5em 0 0.75em 0;
   line-height: 1.2;
   font-weight: 500;
@@ -170,61 +220,61 @@ h6 {
 
 h1 {
   font-size: 2.5rem;
-  text-shadow: 0 0 30px rgba(0, 255, 255, 0.5);
+  text-shadow: 0 0 30px color-mix(in srgb, var(--aiv-action-primary) 50%, transparent);
   margin-top: 0;
 }
 
 h2 {
   font-size: 2rem;
-  color: $neon-magenta;
+  color: var(--aiv-action-secondary);
 }
 
 h3 {
   font-size: 1.5rem;
-  color: $text-accent;
+  color: var(--aiv-action-primary);
 }
 
 h4 {
   font-size: 1.25rem;
-  color: $text-accent;
+  color: var(--aiv-action-primary);
 }
 
 h5 {
   font-size: 1.1rem;
-  color: $text-accent;
+  color: var(--aiv-action-primary);
 }
 
 h6 {
   font-size: 1rem;
-  color: $text-accent;
+  color: var(--aiv-action-primary);
 }
 
 p {
   margin: 1em 0;
-  color: $text-secondary;
+  color: var(--aiv-text-secondary);
 }
 
 a {
-  color: $neon-cyan;
+  color: var(--aiv-action-primary);
   text-decoration: none;
   transition: all 0.3s ease;
 
   &:hover {
-    color: $neon-magenta;
+    color: var(--aiv-action-secondary);
     text-decoration: underline;
-    text-shadow: 0 0 10px rgba(255, 0, 255, 0.5);
+    text-shadow: 0 0 10px color-mix(in srgb, var(--aiv-action-secondary) 50%, transparent);
   }
 }
 
 strong,
 b {
-  color: $text-primary;
+  color: var(--aiv-text-primary);
   font-weight: 600;
 }
 
 em,
 i {
-  color: $text-secondary;
+  color: var(--aiv-text-secondary);
   font-style: italic;
 }
 
@@ -236,7 +286,7 @@ ul,
 ol {
   margin: 1em 0;
   padding-left: 2em;
-  color: $text-secondary;
+  color: var(--aiv-text-secondary);
 }
 
 ul {
@@ -244,7 +294,7 @@ ul {
 
   li::before {
     content: "▸ ";
-    color: $text-accent;
+    color: var(--aiv-action-primary);
     font-weight: bold;
     margin-right: 0.5em;
   }
@@ -258,9 +308,9 @@ ol {
 
     &::before {
       content: counter(item) ". ";
-      color: $text-accent;
+      color: var(--aiv-action-primary);
       font-weight: bold;
-      font-family: $font-mono;
+      font-family: var(--aiv-font-mono);
     }
   }
 }
@@ -275,30 +325,30 @@ li {
    =================================== */
 
 code {
-  font-family: $font-mono;
-  background: $bg-secondary;
+  font-family: var(--aiv-font-mono);
+  background: var(--aiv-bg-surface);
   padding: 0.2em 0.4em;
   border-radius: 4px;
-  color: $text-accent;
+  color: var(--aiv-action-primary);
   font-size: 0.9em;
-  border: 1px solid $border-primary;
+  border: 1px solid var(--aiv-line-subtle);
 }
 
 pre {
-  background: $bg-secondary;
+  background: var(--aiv-bg-surface);
   padding: 1.5em;
   border-radius: 8px;
   overflow-x: auto;
-  border-left: 4px solid $text-accent;
+  border-left: 4px solid var(--aiv-action-primary);
   backdrop-filter: blur(10px);
-  border: 1px solid $border-primary;
+  border: 1px solid var(--aiv-line-subtle);
   margin: 1.5em 0;
 
   code {
     background: none;
     padding: 0;
     border: none;
-    color: $text-secondary;
+    color: var(--aiv-text-secondary);
   }
 }
 
@@ -307,26 +357,26 @@ pre {
    =================================== */
 
 blockquote {
-  border-left: 4px solid $neon-magenta;
+  border-left: 4px solid var(--aiv-action-secondary);
   margin: 1.5em 0;
   padding: 1em 1.5em;
-  background: $bg-glass;
+  background: color-mix(in srgb, var(--aiv-decoration-violet) 10%, transparent);
   backdrop-filter: blur(10px);
   font-style: italic;
   border-radius: 0 8px 8px 0;
-  border: 1px solid $border-primary;
-  border-left: 4px solid $neon-magenta;
+  border: 1px solid var(--aiv-line-subtle);
+  border-left: 4px solid var(--aiv-action-secondary);
 
   p {
     margin: 0;
-    color: $text-secondary;
+    color: var(--aiv-text-secondary);
   }
 
   cite {
     display: block;
     margin-top: 1em;
-    color: $text-muted;
-    font-family: $font-mono;
+    color: var(--aiv-text-muted);
+    font-family: var(--aiv-font-mono);
     font-size: 0.9em;
 
     &::before {
@@ -356,8 +406,8 @@ blockquote {
 
 .site-header {
   backdrop-filter: blur(20px);
-  background: rgba(26, 0, 41, 0.8);
-  border-bottom: 1px solid $border-primary;
+  background: color-mix(in srgb, var(--aiv-bg-surface) 80%, transparent);
+  border-bottom: 1px solid var(--aiv-line-subtle);
   padding: 1rem 0;
   position: sticky;
   top: 0;
@@ -372,9 +422,9 @@ blockquote {
   }
 
   .site-title {
-    font-family: $font-mono;
+    font-family: var(--aiv-font-mono);
     font-size: 1.8rem;
-    color: $text-accent;
+    color: var(--aiv-action-primary);
     text-decoration: none;
     font-weight: 700;
     text-transform: uppercase;
@@ -382,12 +432,12 @@ blockquote {
 
     &::before {
       content: "> ";
-      color: $neon-magenta;
+      color: var(--aiv-action-secondary);
       animation: blink 2s infinite;
     }
 
     &:hover {
-      text-shadow: 0 0 20px rgba(0, 255, 255, 0.7);
+      text-shadow: 0 0 20px color-mix(in srgb, var(--aiv-action-primary) 70%, transparent);
     }
   }
 
@@ -399,8 +449,8 @@ blockquote {
     gap: 2rem;
 
     a {
-      color: $text-secondary;
-      font-family: $font-mono;
+      color: var(--aiv-text-secondary);
+      font-family: var(--aiv-font-mono);
       font-weight: 400;
       text-transform: uppercase;
       letter-spacing: 1px;
@@ -411,16 +461,16 @@ blockquote {
       text-decoration: none;
 
       &:hover {
-        color: $text-accent;
-        border-color: $border-accent;
-        background: $bg-glass;
-        box-shadow: 0 0 20px rgba(0, 255, 255, 0.3);
+        color: var(--aiv-action-primary);
+        border-color: var(--aiv-action-primary);
+        background: color-mix(in srgb, var(--aiv-decoration-violet) 10%, transparent);
+        box-shadow: 0 0 20px color-mix(in srgb, var(--aiv-action-primary) 30%, transparent);
       }
 
       &.active {
-        color: $text-accent;
-        border-color: $border-accent;
-        background: $bg-glass;
+        color: var(--aiv-action-primary);
+        border-color: var(--aiv-action-primary);
+        background: color-mix(in srgb, var(--aiv-decoration-violet) 10%, transparent);
       }
     }
   }
@@ -444,9 +494,9 @@ blockquote {
    =================================== */
 
 .card {
-  background: rgba(26, 0, 41, 0.6);
+  background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent);
   backdrop-filter: blur(20px);
-  border: 1px solid $border-primary;
+  border: 1px solid var(--aiv-line-subtle);
   border-radius: 12px;
   padding: 1.5rem;
   margin: 1rem 0;
@@ -461,13 +511,13 @@ blockquote {
     left: -100%;
     width: 100%;
     height: 100%;
-    background: linear-gradient(90deg, transparent, rgba(0, 255, 255, 0.1), transparent);
+    background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--aiv-action-primary) 10%, transparent), transparent);
     transition: left 0.5s ease;
   }
 
   &:hover {
-    border-color: $border-accent;
-    box-shadow: 0 10px 40px rgba(138, 43, 226, 0.3);
+    border-color: var(--aiv-action-primary);
+    box-shadow: 0 10px 40px color-mix(in srgb, var(--aiv-decoration-violet) 30%, transparent);
     transform: translateY(-5px);
 
     &::before {
@@ -479,7 +529,7 @@ blockquote {
   h4,
   h5,
   h6 {
-    color: $text-accent;
+    color: var(--aiv-action-primary);
     margin-top: 0;
   }
 
@@ -495,10 +545,10 @@ blockquote {
 .btn {
   display: inline-block;
   padding: 1rem 2rem;
-  border: 2px solid $text-accent;
-  color: $text-accent;
+  border: 2px solid var(--aiv-action-primary);
+  color: var(--aiv-action-primary);
   text-decoration: none;
-  font-family: $font-mono;
+  font-family: var(--aiv-font-mono);
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -516,14 +566,14 @@ blockquote {
     left: -100%;
     width: 100%;
     height: 100%;
-    background: $text-accent;
+    background: var(--aiv-action-primary);
     transition: left 0.3s ease;
     z-index: -1;
   }
 
   &:hover {
-    color: $bg-primary;
-    box-shadow: 0 0 30px rgba(0, 255, 255, 0.5);
+    color: var(--aiv-bg-canvas);
+    box-shadow: 0 0 30px color-mix(in srgb, var(--aiv-action-primary) 50%, transparent);
     text-decoration: none;
 
     &::before {
@@ -532,15 +582,15 @@ blockquote {
   }
 
   &.secondary {
-    border-color: $neon-magenta;
-    color: $neon-magenta;
+    border-color: var(--aiv-action-secondary);
+    color: var(--aiv-action-secondary);
 
     &::before {
-      background: $neon-magenta;
+      background: var(--aiv-action-secondary);
     }
 
     &:hover {
-      box-shadow: 0 0 30px rgba(255, 0, 255, 0.5);
+      box-shadow: 0 0 30px color-mix(in srgb, var(--aiv-action-secondary) 50%, transparent);
     }
   }
 
@@ -569,28 +619,28 @@ blockquote {
   gap: 1rem;
   padding: 1.5rem;
   margin: 1rem 0;
-  background: rgba(26, 0, 41, 0.6);
+  background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent);
   backdrop-filter: blur(20px);
-  border-left: 4px solid $neon-magenta;
+  border-left: 4px solid var(--aiv-action-secondary);
   border-radius: 0 12px 12px 0;
-  border: 1px solid $border-primary;
+  border: 1px solid var(--aiv-line-subtle);
   transition: all 0.3s ease;
 
   &:hover {
-    border-color: $border-accent;
-    box-shadow: 0 8px 30px rgba(138, 43, 226, 0.3);
+    border-color: var(--aiv-action-primary);
+    box-shadow: 0 8px 30px color-mix(in srgb, var(--aiv-decoration-violet) 30%, transparent);
     transform: translateY(-2px);
   }
 
   .event-date {
     min-width: 80px;
     text-align: center;
-    font-family: $font-mono;
+    font-family: var(--aiv-font-mono);
     flex-shrink: 0;
 
     .event-month {
-      background: $text-accent;
-      color: $bg-primary;
+      background: var(--aiv-action-primary);
+      color: var(--aiv-bg-canvas);
       padding: 0.25rem;
       font-size: 0.8rem;
       font-weight: 700;
@@ -599,13 +649,13 @@ blockquote {
     }
 
     .event-day {
-      background: $bg-tertiary;
-      color: $text-accent;
+      background: var(--aiv-bg-panel);
+      color: var(--aiv-action-primary);
       padding: 0.5rem;
       font-size: 1.5rem;
       font-weight: 700;
       border-radius: 0 0 4px 4px;
-      border: 1px solid $border-primary;
+      border: 1px solid var(--aiv-line-subtle);
       border-top: none;
     }
   }
@@ -616,18 +666,18 @@ blockquote {
     h3,
     h4 {
       margin: 0 0 0.5rem 0;
-      color: $text-accent;
+      color: var(--aiv-action-primary);
     }
 
     .event-location {
-      color: $text-muted;
+      color: var(--aiv-text-muted);
       font-size: 0.9rem;
       margin: 0.25rem 0;
-      font-family: $font-mono;
+      font-family: var(--aiv-font-mono);
     }
 
     .event-description {
-      color: $text-secondary;
+      color: var(--aiv-text-secondary);
       margin: 0.5rem 0 0 0;
       line-height: 1.6;
     }
@@ -640,9 +690,9 @@ blockquote {
 
 .post-list {
   .post-item {
-    background: rgba(26, 0, 41, 0.6);
+    background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent);
     backdrop-filter: blur(20px);
-    border: 1px solid $border-primary;
+    border: 1px solid var(--aiv-line-subtle);
     border-radius: 12px;
     padding: 1.5rem;
     margin: 1.5rem 0;
@@ -657,14 +707,14 @@ blockquote {
       left: -100%;
       width: 100%;
       height: 100%;
-      background: linear-gradient(90deg, transparent, rgba(0, 255, 255, 0.1), transparent);
+      background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--aiv-action-primary) 10%, transparent), transparent);
       transition: left 0.5s ease;
     }
 
     &:hover {
-      border-color: $border-accent;
+      border-color: var(--aiv-action-primary);
       transform: translateY(-5px);
-      box-shadow: 0 10px 40px rgba(138, 43, 226, 0.3);
+      box-shadow: 0 10px 40px color-mix(in srgb, var(--aiv-decoration-violet) 30%, transparent);
 
       &::before {
         left: 100%;
@@ -675,25 +725,25 @@ blockquote {
       margin: 0 0 0.5rem 0;
 
       a {
-        color: $text-accent;
+        color: var(--aiv-action-primary);
         text-decoration: none;
 
         &:hover {
-          color: $neon-magenta;
-          text-shadow: 0 0 15px rgba(255, 0, 255, 0.5);
+          color: var(--aiv-action-secondary);
+          text-shadow: 0 0 15px color-mix(in srgb, var(--aiv-action-secondary) 50%, transparent);
         }
       }
     }
 
     .post-meta {
-      color: $text-muted;
+      color: var(--aiv-text-muted);
       font-size: 0.9rem;
       margin: 0.5rem 0;
-      font-family: $font-mono;
+      font-family: var(--aiv-font-mono);
     }
 
     .post-excerpt {
-      color: $text-secondary;
+      color: var(--aiv-text-secondary);
       margin: 1rem 0 0 0;
       line-height: 1.6;
     }
@@ -704,32 +754,32 @@ blockquote {
   margin-bottom: 2rem;
 
   .post-meta {
-    color: $text-muted;
-    font-family: $font-mono;
+    color: var(--aiv-text-muted);
+    font-family: var(--aiv-font-mono);
     font-size: 0.9rem;
     margin: 1rem 0;
 
     .post-author {
-      color: $text-accent;
+      color: var(--aiv-action-primary);
     }
 
     .post-category {
-      color: $neon-magenta;
+      color: var(--aiv-action-secondary);
     }
   }
 
   .post-description {
-    background: $bg-glass;
+    background: color-mix(in srgb, var(--aiv-decoration-violet) 10%, transparent);
     backdrop-filter: blur(10px);
     padding: 1rem;
-    border-left: 4px solid $text-accent;
+    border-left: 4px solid var(--aiv-action-primary);
     border-radius: 0 8px 8px 0;
     margin: 1rem 0;
-    border: 1px solid $border-primary;
+    border: 1px solid var(--aiv-line-subtle);
 
     p {
       margin: 0;
-      color: $text-secondary;
+      color: var(--aiv-text-secondary);
       font-style: italic;
     }
   }
@@ -743,14 +793,14 @@ blockquote {
     height: auto;
     border-radius: 8px;
     margin: 1rem 0;
-    border: 1px solid $border-primary;
+    border: 1px solid var(--aiv-line-subtle);
   }
 }
 
 .post-footer {
   margin-top: 3rem;
   padding-top: 2rem;
-  border-top: 1px solid $border-primary;
+  border-top: 1px solid var(--aiv-line-subtle);
 
   .post-footer-content {
     display: flex;
@@ -767,19 +817,19 @@ blockquote {
     align-items: center;
 
     .nav-link {
-      color: $text-accent;
-      font-family: $font-mono;
+      color: var(--aiv-action-primary);
+      font-family: var(--aiv-font-mono);
       font-size: 0.9rem;
       text-decoration: none;
 
       &:hover {
-        color: $neon-magenta;
-        text-shadow: 0 0 10px rgba(255, 0, 255, 0.5);
+        color: var(--aiv-action-secondary);
+        text-shadow: 0 0 10px color-mix(in srgb, var(--aiv-action-secondary) 50%, transparent);
       }
     }
 
     .nav-separator {
-      color: $text-muted;
+      color: var(--aiv-text-muted);
       margin: 0 0.5rem;
     }
   }
@@ -790,8 +840,8 @@ blockquote {
       text-decoration: none;
 
       &:hover {
-        color: $text-accent;
-        text-shadow: 0 0 10px rgba(0, 255, 255, 0.5);
+        color: var(--aiv-action-primary);
+        text-shadow: 0 0 10px color-mix(in srgb, var(--aiv-action-primary) 50%, transparent);
       }
     }
   }
@@ -800,25 +850,25 @@ blockquote {
     text-align: center;
     margin: 2rem 0;
     padding: 1.5rem;
-    background: $bg-glass;
+    background: color-mix(in srgb, var(--aiv-decoration-violet) 10%, transparent);
     backdrop-filter: blur(10px);
     border-radius: 8px;
-    border: 1px solid $border-primary;
+    border: 1px solid var(--aiv-line-subtle);
 
     p {
       margin: 0;
-      color: $text-secondary;
+      color: var(--aiv-text-secondary);
 
       strong {
-        color: $text-primary;
+        color: var(--aiv-text-primary);
       }
 
       a {
-        color: $text-accent;
+        color: var(--aiv-action-primary);
 
         &:hover {
-          color: $neon-cyan;
-          text-shadow: 0 0 10px rgba(0, 255, 255, 0.5);
+          color: var(--aiv-action-primary);
+          text-shadow: 0 0 10px color-mix(in srgb, var(--aiv-action-primary) 50%, transparent);
         }
       }
     }
@@ -833,34 +883,34 @@ table {
   width: 100%;
   border-collapse: collapse;
   margin: 2rem 0;
-  background: rgba(26, 0, 41, 0.6);
+  background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent);
   backdrop-filter: blur(20px);
   border-radius: 8px;
   overflow: hidden;
-  border: 1px solid $border-primary;
+  border: 1px solid var(--aiv-line-subtle);
 
   th,
   td {
     padding: 1rem;
     text-align: left;
-    border-bottom: 1px solid $border-primary;
+    border-bottom: 1px solid var(--aiv-line-subtle);
   }
 
   th {
-    background: rgba(42, 0, 64, 0.8);
-    color: $text-accent;
-    font-family: $font-mono;
+    background: color-mix(in srgb, var(--aiv-bg-panel) 80%, transparent);
+    color: var(--aiv-action-primary);
+    font-family: var(--aiv-font-mono);
     font-weight: 500;
     text-transform: uppercase;
     letter-spacing: 1px;
   }
 
   td {
-    color: $text-secondary;
+    color: var(--aiv-text-secondary);
   }
 
   tr:hover {
-    background: rgba(0, 255, 255, 0.05);
+    background: color-mix(in srgb, var(--aiv-action-primary) 5%, transparent);
   }
 
   tr:last-child {
@@ -877,31 +927,31 @@ table {
 input,
 textarea,
 select {
-  background: rgba(26, 0, 41, 0.6);
+  background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent);
   backdrop-filter: blur(20px);
-  border: 1px solid $border-primary;
+  border: 1px solid var(--aiv-line-subtle);
   border-radius: 6px;
   padding: 0.75rem;
-  color: $text-primary;
-  font-family: $font-sans;
+  color: var(--aiv-text-primary);
+  font-family: var(--aiv-font-body);
   width: 100%;
   margin-bottom: 1rem;
   transition: all 0.3s ease;
 
   &:focus {
     outline: none;
-    border-color: $border-accent;
-    box-shadow: 0 0 20px rgba(0, 255, 255, 0.3);
+    border-color: var(--aiv-action-primary);
+    box-shadow: 0 0 20px color-mix(in srgb, var(--aiv-action-primary) 30%, transparent);
   }
 
   &::placeholder {
-    color: $text-muted;
+    color: var(--aiv-text-muted);
   }
 }
 
 label {
-  color: $text-secondary;
-  font-family: $font-mono;
+  color: var(--aiv-text-secondary);
+  font-family: var(--aiv-font-mono);
   font-size: 0.9rem;
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -914,16 +964,16 @@ label {
    =================================== */
 
 .site-footer {
-  background: rgba(10, 0, 20, 0.9);
+  background: color-mix(in srgb, var(--aiv-bg-canvas) 90%, transparent);
   backdrop-filter: blur(20px);
-  border-top: 1px solid $border-primary;
+  border-top: 1px solid var(--aiv-line-subtle);
   padding: 2rem 0;
   margin-top: 4rem;
 
   .footer-content {
     text-align: center;
-    color: $text-muted;
-    font-family: $font-mono;
+    color: var(--aiv-text-muted);
+    font-family: var(--aiv-font-mono);
 
     .footer-nav,
     .social-links {
@@ -934,13 +984,13 @@ label {
       margin: 1rem 0;
 
       a {
-        color: $text-muted;
+        color: var(--aiv-text-muted);
         text-decoration: none;
         transition: all 0.3s ease;
 
         &:hover {
-          color: $text-accent;
-          text-shadow: 0 0 10px rgba(0, 255, 255, 0.5);
+          color: var(--aiv-action-primary);
+          text-shadow: 0 0 10px color-mix(in srgb, var(--aiv-action-primary) 50%, transparent);
         }
       }
     }
@@ -958,31 +1008,31 @@ label {
 
 // Details/Summary
 details {
-  background: rgba(26, 0, 41, 0.6);
+  background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent);
   backdrop-filter: blur(20px);
-  border: 1px solid $border-primary;
+  border: 1px solid var(--aiv-line-subtle);
   border-radius: 8px;
   margin: 1rem 0;
   overflow: hidden;
 
   summary {
-    background: rgba(42, 0, 64, 0.8);
+    background: color-mix(in srgb, var(--aiv-bg-panel) 80%, transparent);
     padding: 1rem;
     cursor: pointer;
     transition: all 0.3s ease;
-    border-bottom: 1px solid $border-primary;
-    color: $text-accent;
-    font-family: $font-mono;
+    border-bottom: 1px solid var(--aiv-line-subtle);
+    color: var(--aiv-action-primary);
+    font-family: var(--aiv-font-mono);
     font-weight: 500;
 
     &:hover {
-      background: rgba(42, 0, 64, 1);
-      color: $text-primary;
+      background: var(--aiv-bg-panel);
+      color: var(--aiv-text-primary);
     }
   }
 
   &[open] summary {
-    border-bottom: 1px solid $border-primary;
+    border-bottom: 1px solid var(--aiv-line-subtle);
   }
 
   .details-content {
@@ -994,12 +1044,12 @@ details {
 .team-member {
   display: flex;
   gap: 1.5rem;
-  background: rgba(26, 0, 41, 0.6);
+  background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent);
   backdrop-filter: blur(20px);
   padding: 1.5rem;
   border-radius: 12px;
-  border-left: 4px solid $text-accent;
-  border: 1px solid $border-primary;
+  border-left: 4px solid var(--aiv-action-primary);
+  border: 1px solid var(--aiv-line-subtle);
   margin: 1rem 0;
 
   .member-photo {
@@ -1010,11 +1060,11 @@ details {
       height: 120px;
       border-radius: 50%;
       object-fit: cover;
-      border: 2px solid $text-accent;
+      border: 2px solid var(--aiv-action-primary);
       transition: all 0.3s ease;
 
       &:hover {
-        box-shadow: 0 0 30px rgba(0, 255, 255, 0.5);
+        box-shadow: 0 0 30px color-mix(in srgb, var(--aiv-action-primary) 50%, transparent);
         transform: scale(1.05);
       }
     }
@@ -1025,12 +1075,12 @@ details {
 
     h3 {
       margin: 0 0 0.5rem 0;
-      color: $text-accent;
+      color: var(--aiv-action-primary);
     }
 
     .member-position {
-      color: $neon-magenta;
-      font-family: $font-mono;
+      color: var(--aiv-action-secondary);
+      font-family: var(--aiv-font-mono);
       font-size: 0.9rem;
       margin: 0.25rem 0;
       font-weight: bold;
@@ -1038,12 +1088,12 @@ details {
 
     .member-affiliation,
     .member-expertise {
-      color: $text-muted;
+      color: var(--aiv-text-muted);
       font-size: 0.9rem;
       margin: 0.25rem 0;
 
       strong {
-        color: $text-secondary;
+        color: var(--aiv-text-secondary);
       }
     }
   }
@@ -1055,7 +1105,7 @@ details {
 
   &:hover {
     transform: translateX(10px);
-    box-shadow: 0 5px 20px rgba(138, 43, 226, 0.3);
+    box-shadow: 0 5px 20px color-mix(in srgb, var(--aiv-decoration-violet) 30%, transparent);
   }
 }
 
@@ -1069,25 +1119,25 @@ details {
   a,
   span {
     padding: 0.5rem 1rem;
-    border: 1px solid $border-primary;
-    background: rgba(26, 0, 41, 0.6);
+    border: 1px solid var(--aiv-line-subtle);
+    background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent);
     backdrop-filter: blur(20px);
-    color: $text-secondary;
+    color: var(--aiv-text-secondary);
     text-decoration: none;
     border-radius: 4px;
     transition: all 0.3s ease;
-    font-family: $font-mono;
+    font-family: var(--aiv-font-mono);
 
     &:hover {
-      border-color: $border-accent;
-      color: $text-accent;
-      box-shadow: 0 0 15px rgba(0, 255, 255, 0.3);
+      border-color: var(--aiv-action-primary);
+      color: var(--aiv-action-primary);
+      box-shadow: 0 0 15px color-mix(in srgb, var(--aiv-action-primary) 30%, transparent);
     }
 
     &.current {
-      background: $text-accent;
-      color: $bg-primary;
-      border-color: $text-accent;
+      background: var(--aiv-action-primary);
+      color: var(--aiv-bg-canvas);
+      border-color: var(--aiv-action-primary);
     }
   }
 }
@@ -1095,13 +1145,13 @@ details {
 @media (max-width: 768px) {
   // Force dark vaporwave background on all mobile devices
   html {
-    background: $bg-primary !important;
-    background-color: $bg-primary !important;
+    background: var(--aiv-bg-canvas) !important;
+    background-color: var(--aiv-bg-canvas) !important;
   }
   
   body {
-    background: linear-gradient(135deg, $bg-primary 0%, $bg-secondary 50%, $bg-tertiary 100%) !important;
-    background-color: $bg-primary !important;
+    background: linear-gradient(135deg, var(--aiv-bg-canvas) 0%, var(--aiv-bg-surface) 50%, var(--aiv-bg-panel) 100%) !important;
+    background-color: var(--aiv-bg-canvas) !important;
     background-attachment: fixed !important;
     min-height: 100vh !important;
   }
@@ -1131,9 +1181,9 @@ details {
   .card,
   .event-item,
   .post-item {
-    background: $bg-glass !important;
+    background: color-mix(in srgb, var(--aiv-decoration-violet) 10%, transparent) !important;
     backdrop-filter: blur(20px) !important;
-    border: 1px solid $border-primary !important;
+    border: 1px solid var(--aiv-line-subtle) !important;
   }
   
   .container {
@@ -1302,17 +1352,17 @@ details {
 .text-left { text-align: left; }
 .text-right { text-align: right; }
 
-.text-mono { font-family: $font-mono; }
-.text-sans { font-family: $font-sans; }
+.text-mono { font-family: var(--aiv-font-mono); }
+.text-sans { font-family: var(--aiv-font-body); }
 
-.text-primary { color: $text-primary; }
-.text-secondary { color: $text-secondary; }
-.text-muted { color: $text-muted; }
-.text-accent { color: $text-accent; }
+.text-primary { color: var(--aiv-text-primary); }
+.text-secondary { color: var(--aiv-text-secondary); }
+.text-muted { color: var(--aiv-text-muted); }
+.text-accent { color: var(--aiv-action-primary); }
 
-.text-cyan { color: $neon-cyan; }
-.text-magenta { color: $neon-magenta; }
-.text-purple { color: $neon-purple; }
+.text-cyan { color: var(--aiv-action-primary); }
+.text-magenta { color: var(--aiv-action-secondary); }
+.text-purple { color: var(--aiv-decoration-violet); }
 
 .mb-0 { margin-bottom: 0; }
 .mb-1 { margin-bottom: 1rem; }
@@ -1351,9 +1401,9 @@ details {
 
 /* Mobile Navigation Styles */
 .site-header {
-  background: #1a1a1a;
+  background: var(--aiv-legacy-charcoal);
   padding: 1rem 0;
-  border-bottom: 2px solid #00ff00;
+  border-bottom: 2px solid var(--aiv-legacy-green);
   position: relative;
 }
 
@@ -1367,8 +1417,8 @@ details {
 }
 
 .site-title {
-  color: #00ff00;
-  font-family: "JetBrains Mono", monospace;
+  color: var(--aiv-legacy-green);
+  font-family: var(--aiv-font-mono);
   font-size: 1.5rem;
   text-decoration: none;
   font-weight: bold;
@@ -1383,18 +1433,18 @@ details {
 }
 
 .nav-menu a {
-  color: #888;
+  color: var(--aiv-legacy-gray);
   text-decoration: none;
-  font-family: "JetBrains Mono", monospace;
+  font-family: var(--aiv-font-mono);
   transition: color 0.3s ease;
 }
 
 .nav-menu a:hover {
-  color: #00ffff;
+  color: var(--aiv-action-primary);
 }
 
 .nav-menu a.active {
-  color: #00ff00;
+  color: var(--aiv-legacy-green);
 }
 
 .hamburger {
@@ -1413,7 +1463,7 @@ details {
 .hamburger span {
   width: 2rem;
   height: 0.25rem;
-  background: #00ff00;
+  background: var(--aiv-legacy-green);
   border-radius: 10px;
   transition: all 0.3s linear;
   position: relative;
@@ -1454,7 +1504,7 @@ details {
     left: 0;
     right: 0;
     height: 100vh;
-    background: #1a1a1a;
+    background: var(--aiv-legacy-charcoal);
     flex-direction: column;
     justify-content: center;
     align-items: center;
@@ -1508,8 +1558,8 @@ details {
     left: 0;
     right: 0;
     height: 4rem;
-    background: #1a1a1a;
-    border-bottom: 2px solid #00ff00;
+    background: var(--aiv-legacy-charcoal);
+    border-bottom: 2px solid var(--aiv-legacy-green);
   }
 }
 


### PR DESCRIPTION
Move the design system color/font plumbing to `--aiv-*` CSS custom properties and remove the parallel SCSS token variables. Convert existing SCSS and inline component styles to consume runtime tokens while preserving the current legacy visual palette by default.

Add compatibility tokens for legacy cyan, magenta, green, yellow, red, gray, charcoal, divider, and glass values where needed so this remains an architecture-only change. Keep the institutional palette inactive under `.theme-institutional-next`.

This PR changes color architecture only. Visual palette migration is deferred.