### PR TITLE
Update AI Village color palette and theme toggle

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -16,6 +16,22 @@ function isActive(url: string) {
       <nav class="nav-menu" id="nav-menu">
         {primaryNav.map((item) => <a href={item.href} class:list={[{ active: isActive(item.href) }]}>{item.label}</a>)}
       </nav>
+      <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Switch color mode" title="Switch color mode">
+        <svg class="theme-icon theme-icon-sun" aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+          <circle cx="12" cy="12" r="4"></circle>
+          <path d="M12 2v2"></path>
+          <path d="M12 20v2"></path>
+          <path d="m4.93 4.93 1.41 1.41"></path>
+          <path d="m17.66 17.66 1.41 1.41"></path>
+          <path d="M2 12h2"></path>
+          <path d="M20 12h2"></path>
+          <path d="m6.34 17.66-1.41 1.41"></path>
+          <path d="m19.07 4.93-1.41 1.41"></path>
+        </svg>
+        <svg class="theme-icon theme-icon-moon" aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+          <path d="M20.99 12.66A8.99 8.99 0 1 1 11.34 3.01a7 7 0 1 0 9.65 9.65Z"></path>
+        </svg>
+      </button>
       <button class="hamburger" aria-label="Toggle menu" aria-controls="nav-menu" aria-expanded="false" onclick="toggleMenu(this)">
         <span></span>
         <span></span>
@@ -41,4 +57,60 @@ function isActive(url: string) {
   menuItems.forEach((item, index) => {
     item.style.transitionDelay = `${index * 0.1}s`;
   });
+
+  const themeToggle = document.getElementById("theme-toggle");
+  const productionThemes = new Set(["institutional-dark", "institutional-light"]);
+  const systemTheme = window.matchMedia("(prefers-color-scheme: dark)");
+
+  function savedTheme() {
+    try {
+      const value = localStorage.getItem("aiv-theme");
+      if (productionThemes.has(value)) return value;
+      if (value && value !== "auto") localStorage.removeItem("aiv-theme");
+    } catch {
+      return null;
+    }
+
+    return null;
+  }
+
+  function currentEffectiveMode() {
+    const theme = document.documentElement.dataset.theme;
+    if (theme === "institutional-dark") return "dark";
+    if (theme === "institutional-light") return "light";
+    return systemTheme.matches ? "dark" : "light";
+  }
+
+  function updateThemeToggle() {
+    if (!(themeToggle instanceof HTMLButtonElement)) return;
+
+    const mode = currentEffectiveMode();
+    const nextMode = mode === "dark" ? "light" : "dark";
+    const label = `Switch to ${nextMode} mode`;
+
+    themeToggle.dataset.effectiveTheme = mode;
+    themeToggle.setAttribute("aria-label", label);
+    themeToggle.setAttribute("title", label);
+  }
+
+  if (themeToggle instanceof HTMLButtonElement) {
+    updateThemeToggle();
+
+    themeToggle.addEventListener("click", () => {
+      const nextTheme = currentEffectiveMode() === "dark" ? "institutional-light" : "institutional-dark";
+      document.documentElement.dataset.theme = nextTheme;
+
+      try {
+        localStorage.setItem("aiv-theme", nextTheme);
+      } catch {
+        // Ignore storage failures; the current page still updates immediately.
+      }
+
+      updateThemeToggle();
+    });
+
+    systemTheme.addEventListener("change", () => {
+      if (!savedTheme()) updateThemeToggle();
+    });
+  }
 </script>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -11,7 +11,7 @@ const excerpt = post.data.description ?? post.data.excerpt ?? excerptFromBody(po
     <a href={canonicalPostPath(post)}>{post.data.title}</a>
   </h2>
   <div class="post-meta">
-    {post.data.author && <span style="color: var(--aiv-legacy-green);">{Array.isArray(post.data.author) ? post.data.author.join(", ") : post.data.author}</span>}
+    {post.data.author && <span style="color: var(--aiv-text-muted);">{Array.isArray(post.data.author) ? post.data.author.join(", ") : post.data.author}</span>}
     {post.data.author && post.data.date && " • "}
     <time datetime={post.data.date.toISOString()}>{formatDate(post.data.date)}</time>
     {post.data.category && <> • <span style="color: var(--aiv-warning);">#{post.data.category}</span></>}

--- a/src/components/SponsorGrid.astro
+++ b/src/components/SponsorGrid.astro
@@ -15,8 +15,8 @@ const gridStyle = compact
   : "display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.5rem; margin: 2rem 0;";
 const cardStyle = compact ? "align-items: center; padding: 1rem;" : "align-items: center;";
 const logoBoxStyle = compact
-  ? "width: 150px; height: 100px; border-radius: 5px; background: #fff; display: flex; align-items: center; justify-content: center; border: 1px solid var(--aiv-legacy-green); padding: 16px;"
-  : "width: 240px; height: 240px; border-radius: 10%; background: #fff; display: flex; align-items: center; justify-content: center; border: 2px solid var(--aiv-legacy-green); padding: 20px;";
+  ? "width: 150px; height: 100px; border-radius: 5px; background: #fff; display: flex; align-items: center; justify-content: center; border: 1px solid var(--aiv-card-border); padding: 16px;"
+  : "width: 240px; height: 240px; border-radius: 10%; background: #fff; display: flex; align-items: center; justify-content: center; border: 2px solid var(--aiv-card-border); padding: 20px;";
 const logoStyle = compact ? "max-width: 120px; max-height: 70px; object-fit: contain;" : "max-width: 200px; max-height: 200px; object-fit: contain;";
 const nameStyle = compact ? "font-size: 1rem; margin: 0.75rem 0 0;" : undefined;
 ---

--- a/src/components/VolunteerCard.astro
+++ b/src/components/VolunteerCard.astro
@@ -7,25 +7,25 @@ const initials = `${volunteer.data.first_name.slice(0, 1)}${volunteer.data.last_
 const fullName = `${volunteer.data.first_name} ${volunteer.data.last_name}`;
 ---
 
-<div class="team-member" style="display: flex; gap: 1.5rem; background: var(--aiv-legacy-charcoal); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-legacy-green);">
+<div class="team-member" style="display: flex; gap: 1.5rem; background: var(--aiv-card-bg); border: 1px solid var(--aiv-card-border); box-shadow: var(--aiv-card-shadow); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-action-secondary);">
   <div class="member-photo" style="flex-shrink: 0;">
     {volunteer.data.profile ? (
       <img
         src={`/assets/images/profiles/${volunteer.data.profile}`}
         alt={fullName}
-        style="width: 120px; height: 120px; border-radius: 50%; object-fit: cover; border: 2px solid var(--aiv-legacy-green);"
+        style="width: 120px; height: 120px; border-radius: 50%; object-fit: cover; border: 2px solid var(--aiv-card-hover-border);"
       />
     ) : (
-      <div style="width: 120px; height: 120px; border-radius: 50%; background: var(--aiv-legacy-divider); display: flex; align-items: center; justify-content: center; border: 2px solid var(--aiv-legacy-green);">
-        <span style="color: var(--aiv-legacy-green); font-size: 2rem; font-family: var(--aiv-font-mono);">{initials}</span>
+      <div style="width: 120px; height: 120px; border-radius: 50%; background: var(--aiv-nested-bg); display: flex; align-items: center; justify-content: center; border: 2px solid var(--aiv-card-hover-border);">
+        <span style="color: var(--aiv-brand-primary); font-size: 2rem; font-family: var(--aiv-font-mono);">{initials}</span>
       </div>
     )}
   </div>
   <div class="member-info" style="flex: 1;">
-    <h3 style="margin: 0 0 0.5rem 0; color: var(--aiv-legacy-green);">{fullName}</h3>
-    {volunteer.data.position && <div style="color: var(--aiv-warning); font-family: var(--aiv-font-mono); font-size: 0.9rem; margin: 0.25rem 0;"><strong>{volunteer.data.position}</strong></div>}
-    {volunteer.data.affiliation && <div style="color: var(--aiv-legacy-gray); font-size: 0.9rem; margin: 0.25rem 0;"><strong>Affiliation:</strong> {volunteer.data.affiliation}</div>}
-    {volunteer.data.expertise && <div style="color: var(--aiv-legacy-gray); font-size: 0.9rem; margin: 0.25rem 0;"><strong>Expertise:</strong> {volunteer.data.expertise}</div>}
-    {volunteer.data.bio && Content && <div style="margin-top: 1rem; color: var(--aiv-legacy-light-text); line-height: 1.6;"><Content /></div>}
+    <h3 style="margin: 0 0 0.5rem 0; color: var(--aiv-text-primary);">{fullName}</h3>
+    {volunteer.data.position && <div style="color: var(--aiv-action-secondary); font-family: var(--aiv-font-mono); font-size: 0.9rem; margin: 0.25rem 0;"><strong>{volunteer.data.position}</strong></div>}
+    {volunteer.data.affiliation && <div style="color: var(--aiv-text-muted); font-size: 0.9rem; margin: 0.25rem 0;"><strong>Affiliation:</strong> {volunteer.data.affiliation}</div>}
+    {volunteer.data.expertise && <div style="color: var(--aiv-text-muted); font-size: 0.9rem; margin: 0.25rem 0;"><strong>Expertise:</strong> {volunteer.data.expertise}</div>}
+    {volunteer.data.bio && Content && <div style="margin-top: 1rem; color: var(--aiv-text-secondary); line-height: 1.6;"><Content /></div>}
   </div>
 </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -19,8 +19,24 @@ type Props = {
 ---
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="auto">
   <head>
+    <script is:inline>
+      (() => {
+        const allowed = new Set(["auto", "institutional-dark", "institutional-light"]);
+        let selectedTheme = "auto";
+
+        try {
+          const savedTheme = localStorage.getItem("aiv-theme");
+          if (allowed.has(savedTheme)) selectedTheme = savedTheme;
+          else if (savedTheme) localStorage.removeItem("aiv-theme");
+        } catch {
+          selectedTheme = "auto";
+        }
+
+        document.documentElement.dataset.theme = selectedTheme;
+      })();
+    </script>
     <SeoHead {...Astro.props} />
   </head>
   <body>

--- a/src/layouts/EventLayout.astro
+++ b/src/layouts/EventLayout.astro
@@ -19,12 +19,12 @@ const scheduleLinks = scheduleRoutesForEvent(event.id);
 <BaseLayout title={event.data.title} description={event.data.description} canonical={url} type="event" eventDate={event.data.date} eventLocation={event.data.location}>
   <article class="event">
     <header class="event-header" style="margin-bottom: 2rem;">
-      <h1 style="color: var(--aiv-legacy-green); margin: 0 0 1rem 0;">{event.data.title}</h1>
-      <div class="event-meta" style="display: flex; flex-wrap: wrap; gap: 2rem; margin: 1rem 0; color: var(--aiv-legacy-gray); font-family: var(--aiv-font-mono);">
+      <h1 style="color: var(--aiv-action-primary); margin: 0 0 1rem 0;">{event.data.title}</h1>
+      <div class="event-meta" style="display: flex; flex-wrap: wrap; gap: 2rem; margin: 1rem 0; color: var(--aiv-text-muted); font-family: var(--aiv-font-mono);">
         <div><strong style="color: var(--aiv-warning);">📅 Date:</strong> <time datetime={isoDate(event.data.date)}>{formatDate(event.data.date)}</time></div>
         {event.data.location && <div><strong style="color: var(--aiv-warning);">📍 Location:</strong> {event.data.location}</div>}
       </div>
-      {event.data.description && <div class="event-description" style="background: var(--aiv-legacy-charcoal); padding: 1rem; border-left: 4px solid var(--aiv-risk); border-radius: 0 5px 5px 0; margin: 1rem 0;"><p style="margin: 0; color: var(--aiv-legacy-light-text); font-size: 1.1rem;">{event.data.description}</p></div>}
+      {event.data.description && <div class="event-description" style="background: var(--aiv-nested-bg); padding: 1rem; border: 1px solid var(--aiv-nested-border); border-left: 4px solid var(--aiv-action-primary); border-radius: 0 5px 5px 0; margin: 1rem 0;"><p style="margin: 0; color: var(--aiv-text-secondary); font-size: 1.1rem;">{event.data.description}</p></div>}
     </header>
     <div class="event-content" style="line-height: 1.7;">
       <Content />
@@ -37,25 +37,25 @@ const scheduleLinks = scheduleRoutesForEvent(event.id);
         </ul>
       </section>
     )}
-    <footer class="event-footer" style="margin-top: 3rem; padding-top: 2rem; border-top: 1px solid var(--aiv-legacy-divider);">
-      <div style="text-align: center; margin: 2rem 0; padding: 1.5rem; background: var(--aiv-legacy-charcoal); border-radius: 5px;">
-        <p style="margin: 0 0 1rem 0; color: var(--aiv-legacy-green); font-weight: bold;">🎪 Interested in attending or presenting at AI Village events?</p>
+    <footer class="event-footer" style="margin-top: 3rem; padding-top: 2rem; border-top: 1px solid var(--aiv-rule-color);">
+      <div style="text-align: center; margin: 2rem 0; padding: 1.5rem; background: var(--aiv-card-bg); border: 1px solid var(--aiv-card-border); box-shadow: var(--aiv-card-shadow); border-radius: 5px;">
+        <p style="margin: 0 0 1rem 0; color: var(--aiv-brand-primary); font-weight: bold;">🎪 Interested in attending or presenting at AI Village events?</p>
         <div style="display: flex; justify-content: center; gap: 1rem; flex-wrap: wrap;">
           <a href="/discord/" style="color: var(--aiv-action-primary);">Join our Discord</a>
-          <span style="color: var(--aiv-legacy-dim);">•</span>
+          <span style="color: var(--aiv-text-muted);">•</span>
           <a href="https://forms.gle/vCrz3zpR8xHCsTtJ8" target="_blank" style="color: var(--aiv-action-primary);">Volunteer Application</a>
-          <span style="color: var(--aiv-legacy-dim);">•</span>
+          <span style="color: var(--aiv-text-muted);">•</span>
           <a href="/events/" style="color: var(--aiv-action-primary);">All Events</a>
         </div>
       </div>
       <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; margin-top: 2rem;">
         <div class="event-navigation">
           {previous && <a href={eventPath(previous)} style="color: var(--aiv-action-primary);">← {truncate(previous.data.title, 30)}</a>}
-          {previous && next && <span style="color: var(--aiv-legacy-dim); margin: 0 1rem;">|</span>}
+          {previous && next && <span style="color: var(--aiv-text-muted); margin: 0 1rem;">|</span>}
           {next && <a href={eventPath(next)} style="color: var(--aiv-action-primary);">{truncate(next.data.title, 30)} →</a>}
         </div>
         <div class="event-share">
-          <a href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(event.data.title)}&via=aivillage_dc`} target="_blank" style="color: #1DA1F2; margin: 0 0.5rem;">Share Event</a>
+          <a href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(event.data.title)}&via=aivillage_dc`} target="_blank" style="color: var(--aiv-action-primary); margin: 0 0.5rem;">Share Event</a>
         </div>
       </div>
     </footer>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,7 +5,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 <BaseLayout title="404" canonical="/404.html">
   <div class="card" style="text-align: center;">
     <h1>404</h1>
-    <p style="color: var(--aiv-legacy-gray);">Page not found.</p>
+    <p style="color: var(--aiv-text-muted);">Page not found.</p>
     <p><a href="/" style="color: var(--aiv-action-primary);">Return home</a></p>
   </div>
 </BaseLayout>

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -16,7 +16,7 @@ for (const volunteer of volunteers) {
 <BaseLayout title="About" canonical="/about/">
   <h1>About AI Village</h1>
   <div style="text-align: center; margin: 2rem 0;">
-    <p style="color: var(--aiv-legacy-gray); font-size: 1.1rem;">
+    <p style="color: var(--aiv-text-muted); font-size: 1.1rem;">
       AI Village is a community of hackers and data scientists working to educate the world on the use and abuse of artificial intelligence in security and privacy.
     </p>
   </div>
@@ -39,15 +39,15 @@ for (const volunteer of volunteers) {
       return (
         <>
           <VolunteerCard volunteer={volunteer} Content={Content} />
-          {index < volunteers.length - 1 && <hr style="border: none; border-top: 1px solid var(--aiv-legacy-divider); margin: 1rem 0;" />}
+          {index < volunteers.length - 1 && <hr style="border: none; border-top: 1px solid var(--aiv-rule-color); margin: 1rem 0;" />}
         </>
       );
     })}
   </div>
   <hr />
   <h2 id="-join-our-team">Join the Work</h2>
-  <div style="background: var(--aiv-legacy-charcoal); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-risk); margin: 2rem 0;">
-    <h4 style="color: var(--aiv-risk); margin-top: 0;">Get Involved</h4>
+  <div style="background: var(--aiv-card-bg); border: 1px solid var(--aiv-card-border); box-shadow: var(--aiv-card-shadow); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-action-primary); margin: 2rem 0;">
+    <h4 style="color: var(--aiv-action-primary); margin-top: 0;">Get Involved</h4>
     <p>AI Village welcomes help from researchers, engineers, educators, organizers, and community builders.</p>
     <div style="margin-top: 1.5rem;">
       <a href="https://forms.gle/vCrz3zpR8xHCsTtJ8" target="_blank" rel="noopener noreferrer" style="color: var(--aiv-action-primary); font-weight: bold;">→ Submit a volunteer application</a>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -10,7 +10,7 @@ const posts = sortPosts(await getCollection("blog", ({ data }) => !data.draft));
 <BaseLayout title="Blog" canonical="/blog/">
   <h1>Blog</h1>
   <div style="text-align: center; margin: 2rem 0;">
-    <p style="color: var(--aiv-legacy-gray); font-size: 1.1rem;">
+    <p style="color: var(--aiv-text-muted); font-size: 1.1rem;">
       Research insights, event recaps, and perspectives on AI security from our community.
     </p>
   </div>
@@ -18,10 +18,10 @@ const posts = sortPosts(await getCollection("blog", ({ data }) => !data.draft));
   <div class="post-list">
     {posts.map((post) => <PostCard post={post} />)}
   </div>
-  {posts.length === 0 && <div class="card" style="text-align: center;"><h3 style="color: var(--aiv-legacy-gray);">No blog posts yet</h3><p style="color: var(--aiv-legacy-dim);">Check back soon for updates from the AI Village community!</p></div>}
+  {posts.length === 0 && <div class="card" style="text-align: center;"><h3 style="color: var(--aiv-text-muted);">No blog posts yet</h3><p style="color: var(--aiv-text-muted);">Check back soon for updates from the AI Village community!</p></div>}
   <hr />
-  <div style="background: var(--aiv-legacy-charcoal); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-legacy-green); margin: 2rem 0;">
-    <h4 style="color: var(--aiv-legacy-green); margin-top: 0;">📝 Want to Contribute?</h4>
+  <div style="background: var(--aiv-card-bg); border: 1px solid var(--aiv-card-border); box-shadow: var(--aiv-card-shadow); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-action-primary); margin: 2rem 0;">
+    <h4 style="color: var(--aiv-action-primary); margin-top: 0;">📝 Want to Contribute?</h4>
     <p>We welcome guest posts from the community! Topics we're interested in:</p>
     <ul>
       <li>AI security research and findings</li>

--- a/src/pages/discord/index.astro
+++ b/src/pages/discord/index.astro
@@ -5,16 +5,16 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 <BaseLayout title="Discord Community" canonical="/discord/">
   <h1>Discord Community</h1>
   <div style="text-align: center; margin: 2rem 0;">
-    <h2 style="color: var(--aiv-legacy-green);">Join the AI Village Discord</h2>
-    <p style="color: var(--aiv-legacy-gray); font-size: 1.1rem;">Connect with researchers, hackers, and AI security enthusiasts from around the world.</p>
+    <h2 style="color: var(--aiv-action-primary);">Join the AI Village Discord</h2>
+    <p style="color: var(--aiv-text-muted); font-size: 1.1rem;">Connect with researchers, hackers, and AI security enthusiasts from around the world.</p>
     <div style="margin: 2rem 0;">
-      <a href="https://discord.com/invite/GX5fhfT" target="_blank" style="background: #5865F2; color: var(--aiv-text-primary); padding: 1rem 2rem; border-radius: 5px; text-decoration: none; font-weight: bold; font-size: 1.1rem;">🎮 Join Discord Server</a>
+      <a href="https://discord.com/invite/GX5fhfT" target="_blank" style="background: var(--aiv-brand-discord-bg); color: var(--aiv-brand-discord-text); padding: 1rem 2rem; border-radius: 5px; text-decoration: none; font-weight: bold; font-size: 1.1rem;">🎮 Join Discord Server</a>
     </div>
   </div>
   <hr />
   <h2>🚀 Getting Started</h2>
-  <div class="card" style="background: var(--aiv-legacy-charcoal); border-left: 4px solid var(--aiv-legacy-green);">
-    <h3 style="color: var(--aiv-legacy-green); margin-top: 0;">📝 First Steps</h3>
+  <div class="card" style="background: var(--aiv-card-bg); border-left: 4px solid var(--aiv-action-primary);">
+    <h3 style="color: var(--aiv-action-primary); margin-top: 0;">📝 First Steps</h3>
     <ol style="line-height: 1.8;">
       <li><strong>Join the server</strong> using the link above</li>
       <li><strong>Introduce yourself</strong> in the <code>#start-here</code> channel</li>
@@ -22,7 +22,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
       <li><strong>Explore channels</strong> and find your interests</li>
       <li><strong>Participate</strong> in discussions and events</li>
     </ol>
-    <div style="background: var(--aiv-legacy-divider); padding: 1rem; border-radius: 5px; margin: 1rem 0;">
+    <div style="background: var(--aiv-nested-bg); border: 1px solid var(--aiv-nested-border); padding: 1rem; border-radius: 5px; margin: 1rem 0;">
       <p style="margin: 0;"><strong>⚠️ Important:</strong> When you first join, you'll only have access to <code>#start-here</code>. Drop a note introducing yourself, and someone will give you the "Villager" role for full access!</p>
     </div>
   </div>
@@ -35,33 +35,33 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
   <hr />
   <h2>🏆 Community Roles</h2>
   <div class="role-hierarchy" style="margin: 2rem 0;">
-    <div class="role-card" style="background: var(--aiv-legacy-charcoal); padding: 1rem; margin: 1rem 0; border-left: 4px solid var(--aiv-legacy-gray); border-radius: 0 5px 5px 0;"><h4 style="color: var(--aiv-legacy-gray); margin: 0 0 0.5rem 0;">👤 Villager</h4><p style="margin: 0; color: var(--aiv-legacy-light-text);">Basic member role with access to most channels. Granted after introduction in #start-here.</p></div>
-    <div class="role-card" style="background: var(--aiv-legacy-charcoal); padding: 1rem; margin: 1rem 0; border-left: 4px solid var(--aiv-legacy-green); border-radius: 0 5px 5px 0;"><h4 style="color: var(--aiv-legacy-green); margin: 0 0 0.5rem 0;">⭐ ElderVillager</h4><p style="margin: 0; color: var(--aiv-legacy-light-text);">Active community members who have contributed talks, workshops, or sustained participation. Can invite new members and promote to Villager role.</p></div>
-    <div class="role-card" style="background: var(--aiv-legacy-charcoal); padding: 1rem; margin: 1rem 0; border-left: 4px solid var(--aiv-warning); border-radius: 0 5px 5px 0;"><h4 style="color: var(--aiv-warning); margin: 0 0 0.5rem 0;">🛡️ Officer</h4><p style="margin: 0; color: var(--aiv-legacy-light-text);">Community leaders who have organized substantial events or content. Have moderation powers and can help establish new initiatives.</p></div>
-    <div class="role-card" style="background: var(--aiv-legacy-charcoal); padding: 1rem; margin: 1rem 0; border-left: 4px solid var(--aiv-risk); border-radius: 0 5px 5px 0;"><h4 style="color: var(--aiv-risk); margin: 0 0 0.5rem 0;">👑 Board</h4><p style="margin: 0; color: var(--aiv-legacy-light-text);">AI Village board members with full moderation powers. Contact for harassment issues or code of conduct violations.</p></div>
+    <div class="role-card" style="background: var(--aiv-card-bg); border: 1px solid var(--aiv-card-border); padding: 1rem; margin: 1rem 0; border-left: 4px solid var(--aiv-text-muted); border-radius: 0 5px 5px 0;"><h4 style="color: var(--aiv-text-muted); margin: 0 0 0.5rem 0;">👤 Villager</h4><p style="margin: 0; color: var(--aiv-text-secondary);">Basic member role with access to most channels. Granted after introduction in #start-here.</p></div>
+    <div class="role-card" style="background: var(--aiv-card-bg); border: 1px solid var(--aiv-card-border); padding: 1rem; margin: 1rem 0; border-left: 4px solid var(--aiv-accent-field); border-radius: 0 5px 5px 0;"><h4 style="color: var(--aiv-accent-field); margin: 0 0 0.5rem 0;">⭐ ElderVillager</h4><p style="margin: 0; color: var(--aiv-text-secondary);">Active community members who have contributed talks, workshops, or sustained participation. Can invite new members and promote to Villager role.</p></div>
+    <div class="role-card" style="background: var(--aiv-card-bg); border: 1px solid var(--aiv-card-border); padding: 1rem; margin: 1rem 0; border-left: 4px solid var(--aiv-warning); border-radius: 0 5px 5px 0;"><h4 style="color: var(--aiv-warning); margin: 0 0 0.5rem 0;">🛡️ Officer</h4><p style="margin: 0; color: var(--aiv-text-secondary);">Community leaders who have organized substantial events or content. Have moderation powers and can help establish new initiatives.</p></div>
+    <div class="role-card" style="background: var(--aiv-card-bg); border: 1px solid var(--aiv-card-border); padding: 1rem; margin: 1rem 0; border-left: 4px solid var(--aiv-risk); border-radius: 0 5px 5px 0;"><h4 style="color: var(--aiv-risk); margin: 0 0 0.5rem 0;">👑 Board</h4><p style="margin: 0; color: var(--aiv-text-secondary);">AI Village board members with full moderation powers. Contact for harassment issues or code of conduct violations.</p></div>
   </div>
   <hr />
   <h2>🎯 Popular Channels</h2>
   <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1rem; margin: 2rem 0;">
     {["#general:General discussion and off-topic conversations", "#research:AI security research discussions and paper reviews", "#events:Announcements and discussions about upcoming events", "#tools-and-code:Sharing tools, code, and technical resources", "#job-board:AI security job postings and career discussions", "#ctf-discussion:CTF announcements, team formation, and writeups"].map((item) => {
       const [name, text] = item.split(":");
-      return <div class="card"><h4 style="color: var(--aiv-legacy-green); margin-top: 0;">{name}</h4><p>{text}</p></div>;
+      return <div class="card"><h4 style="color: var(--aiv-text-primary); margin-top: 0;">{name}</h4><p>{text}</p></div>;
     })}
   </div>
   <hr />
   <h2>📅 Regular Events</h2>
   <div class="events-grid" style="margin: 2rem 0;">
-    <div class="card" style="text-align: center;"><h4 style="color: var(--aiv-warning); margin-top: 0;">📚 Hacker Journal Club</h4><p style="color: var(--aiv-legacy-gray); font-family: var(--aiv-font-mono);">Wednesdays at 5 PM PST / 8 PM EST</p><p>Discuss academic papers with industry perspective, covering everything from ML security to policy.</p></div>
-    <div class="card" style="text-align: center;"><h4 style="color: var(--aiv-warning); margin-top: 0;">🔒 Privacy & Ethics Journal Club</h4><p style="color: var(--aiv-legacy-gray); font-family: var(--aiv-font-mono);">Tuesdays at 5 PM PST / 8 PM EST</p><p>Interdisciplinary analysis of AI systems from theoretical and practical perspectives.</p></div>
+    <div class="card" style="text-align: center;"><h4 style="color: var(--aiv-warning); margin-top: 0;">📚 Hacker Journal Club</h4><p style="color: var(--aiv-text-muted); font-family: var(--aiv-font-mono);">Wednesdays at 5 PM PST / 8 PM EST</p><p>Discuss academic papers with industry perspective, covering everything from ML security to policy.</p></div>
+    <div class="card" style="text-align: center;"><h4 style="color: var(--aiv-warning); margin-top: 0;">🔒 Privacy & Ethics Journal Club</h4><p style="color: var(--aiv-text-muted); font-family: var(--aiv-font-mono);">Tuesdays at 5 PM PST / 8 PM EST</p><p>Interdisciplinary analysis of AI systems from theoretical and practical perspectives.</p></div>
   </div>
-  <div style="background: var(--aiv-legacy-charcoal); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-action-primary); margin: 2rem 0;">
+  <div style="background: var(--aiv-card-bg); border: 1px solid var(--aiv-card-border); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-action-primary); margin: 2rem 0;">
     <h4 style="color: var(--aiv-action-primary); margin-top: 0;">📅 Event Updates</h4>
     <p>Use the events archive for upcoming AI Village appearances and past schedules.</p>
     <p style="margin-bottom: 0;"><a href="/events/" style="color: var(--aiv-action-primary); font-weight: bold;">View AI Village events</a></p>
   </div>
   <hr />
   <h2>❓ Need Help?</h2>
-  <div style="background: var(--aiv-legacy-charcoal); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-risk);">
+  <div style="background: var(--aiv-card-bg); border: 1px solid var(--aiv-card-border); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-risk);">
     <h4 style="color: var(--aiv-risk); margin-top: 0;">🆘 Support & Issues</h4>
     <p>If you experience harassment or have concerns about community behavior:</p>
     <ul><li><strong>Contact Officers or Board members</strong> directly via DM</li><li><strong>Use the server reporting system</strong> for serious issues</li><li><strong>Remember:</strong> We have zero tolerance for harassment</li></ul>

--- a/src/pages/grt/index.astro
+++ b/src/pages/grt/index.astro
@@ -22,7 +22,7 @@ const events = (await getCollection("events")).filter((event) => `${event.data.t
     This page keeps the public claims narrow: it links the existing source material and gives visitors a single place to understand the program context without adding unsupported partner, scale, or outcome claims.
   </p>
 
-  <div class="card" style="border-left: 4px solid var(--aiv-legacy-green);">
+  <div class="card" style="border-left: 4px solid var(--aiv-action-primary);">
     <h2 style="margin-top: 0;">Program Threads</h2>
     <ul>
       <li>GRT history and lessons from the DEF CON 31 recap.</li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ const latestPost = posts[0];
 <BaseLayout title="Home" canonical="/">
   <div style="text-align: center; margin: 3rem 0;">
     <h1 class="glitch cursor" data-text="AI VILLAGE">AI VILLAGE</h1>
-    <p style="font-size: 1.2rem; color: var(--aiv-legacy-gray); font-family: var(--aiv-font-mono);">
+    <p style="font-size: 1.2rem; color: var(--aiv-text-muted); font-family: var(--aiv-font-mono);">
       A community of hackers and data scientists working to educate the world on the use and abuse of artificial intelligence in security and privacy.
     </p>
   </div>
@@ -33,9 +33,9 @@ const latestPost = posts[0];
     </style>
 
     <div class="card">
-      <h3 style="color: var(--aiv-legacy-green); margin-top: 0;">🔥 Upcoming Events</h3>
+      <h3 style="color: var(--aiv-brand-primary); margin-top: 0;">🔥 Upcoming Events</h3>
       {upcomingEvent ? (
-        <div class="event-item" style="background: var(--aiv-legacy-charcoal); border-left: 4px solid var(--aiv-risk);">
+        <div class="event-item" style="background: var(--aiv-nested-bg); border: 1px solid var(--aiv-nested-border); border-left: 4px solid var(--aiv-card-hover-border);">
           <DateBadge date={upcomingEvent.data.date} />
           <div class="event-content">
             <h4 style="margin: 0;"><a href={eventPath(upcomingEvent)}>{upcomingEvent.data.title}</a></h4>
@@ -44,23 +44,23 @@ const latestPost = posts[0];
           </div>
         </div>
       ) : (
-        <p style="color: var(--aiv-legacy-gray);">No upcoming events at this time.</p>
+        <p style="color: var(--aiv-text-muted);">No upcoming events at this time.</p>
       )}
       <p style="margin-top: 1rem;"><a href="/events/" style="color: var(--aiv-action-primary);">→ View all events</a></p>
     </div>
 
     <div class="card">
-      <h3 style="color: var(--aiv-legacy-green); margin-top: 0;">📝 Latest Blog Post</h3>
+      <h3 style="color: var(--aiv-brand-primary); margin-top: 0;">📝 Latest Blog Post</h3>
       {latestPost ? (
         <>
           <h4 style="margin: 0.5rem 0;"><a href={canonicalPostPath(latestPost)}>{latestPost.data.title}</a></h4>
-          <div style="color: var(--aiv-legacy-gray); font-size: 0.9rem; font-family: var(--aiv-font-mono); margin: 0.5rem 0;">
+          <div style="color: var(--aiv-text-muted); font-size: 0.9rem; font-family: var(--aiv-font-mono); margin: 0.5rem 0;">
             By {Array.isArray(latestPost.data.author) ? latestPost.data.author.join(", ") : latestPost.data.author} • {formatShortDate(latestPost.data.date)}
           </div>
           <div style="margin: 1rem 0;">{latestPost.data.description ?? excerptFromBody(latestPost.body ?? "", 20)}</div>
         </>
       ) : (
-        <p style="color: var(--aiv-legacy-gray);">No blog posts yet.</p>
+        <p style="color: var(--aiv-text-muted);">No blog posts yet.</p>
       )}
       <p style="margin-top: 1rem;"><a href="/blog/" style="color: var(--aiv-action-primary);">→ Read all posts</a></p>
     </div>
@@ -73,7 +73,7 @@ const latestPost = posts[0];
 
   <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.5rem; margin: 2rem 0;">
     <div class="card" style="text-align: center;">
-      <h4 style="color: var(--aiv-warning);">🛡️ Security Research</h4>
+      <h4 style="color: var(--aiv-accent-blue);">🛡️ Security Research</h4>
       <p>Exploring vulnerabilities and defenses in AI systems through hands-on research and experimentation.</p>
     </div>
     <div class="card" style="text-align: center;">
@@ -81,7 +81,7 @@ const latestPost = posts[0];
       <p>Teaching the security community about AI risks and the AI community about security practices.</p>
     </div>
     <div class="card" style="text-align: center;">
-      <h4 style="color: var(--aiv-warning);">🤝 Community</h4>
+      <h4 style="color: var(--aiv-action-secondary);">🤝 Community</h4>
       <p>Building bridges between hackers, data scientists, researchers, and policy makers.</p>
     </div>
   </div>
@@ -117,7 +117,7 @@ const latestPost = posts[0];
   <hr />
 
   <h2 id="-get-involved">🚀 Get Involved</h2>
-  <div style="background: var(--aiv-legacy-charcoal); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-legacy-green);">
+  <div style="background: var(--aiv-card-bg); border: 1px solid var(--aiv-card-border); box-shadow: var(--aiv-card-shadow); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-action-secondary);">
     <p><strong>Want to join our community?</strong></p>
     <ul>
       <li><a href="https://discord.com/invite/GX5fhfT">Join our Discord</a> - Chat with fellow researchers and stay updated</li>

--- a/src/pages/learn/index.astro
+++ b/src/pages/learn/index.astro
@@ -34,7 +34,7 @@ const additionalWorkshopDirectories = [
     This is not a complete curriculum. It is a clear entry point into the open workshop infrastructure that already exists and can grow into more structured learning paths.
   </p>
 
-  <div class="card" style="border-left: 4px solid var(--aiv-legacy-green);">
+  <div class="card" style="border-left: 4px solid var(--aiv-action-primary);">
     <h2 style="margin-top: 0;">Workshop Philosophy</h2>
     <blockquote style="color: var(--aiv-text-secondary); font-size: 1.2rem; margin: 1rem 0;">
       "get them excited to learn"
@@ -42,7 +42,7 @@ const additionalWorkshopDirectories = [
     <p>
       AIV's workshop philosophy is not that every participant masters the skill in the room. The goal is to make the topic accessible, spark interest, and give people a path to continue learning.
     </p>
-    <p style="color: var(--aiv-legacy-gray); font-size: 0.95rem;">Source: AIV Workshops contributor guidelines.</p>
+    <p style="color: var(--aiv-text-muted); font-size: 0.95rem;">Source: AIV Workshops contributor guidelines.</p>
   </div>
 
   <hr />
@@ -56,7 +56,7 @@ const additionalWorkshopDirectories = [
       </article>
     ))}
   </div>
-  <p style="color: var(--aiv-legacy-gray);">
+  <p style="color: var(--aiv-text-muted);">
     Additional workshop directories in the public repository:
     {additionalWorkshopDirectories.map((workshop, index) => (
       <>

--- a/src/styles/_events.scss
+++ b/src/styles/_events.scss
@@ -1,15 +1,16 @@
 /* === Event-specific overrides and additions === */
 
-/* Ensure event items use dark theme consistently */
+/* Ensure event items use the nested event surface consistently */
 .event-item {
-  background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent) !important;
+  background: var(--aiv-nested-bg) !important;
   backdrop-filter: blur(20px) !important;
-  border: 1px solid color-mix(in srgb, var(--aiv-decoration-violet) 40%, transparent) !important;
+  border: 1px solid var(--aiv-nested-border) !important;
+  box-shadow: var(--aiv-card-shadow) !important;
 }
 
 .event-date {
-  background-color: var(--aiv-bg-panel) !important;
-  color: var(--aiv-action-primary) !important;
+  background-color: var(--aiv-bg-raised) !important;
+  color: var(--aiv-brand-primary) !important;
 }
 
 .future-events .event-description,
@@ -33,7 +34,7 @@
   padding: 0;
   font-style: italic;
   font-size: 0.75rem;
-  color: var(--aiv-legacy-bootstrap-muted);
+  color: var(--aiv-text-muted);
   margin-top: 0.25rem;
 }
 
@@ -48,9 +49,9 @@
   margin-top: 1rem;
   margin-bottom: 1.5rem;
   color: var(--aiv-action-primary) !important;
-  background: color-mix(in srgb, var(--aiv-bg-panel) 80%, transparent) !important;
+  background: var(--aiv-nested-bg) !important;
   backdrop-filter: blur(20px);
-  border: 1px solid color-mix(in srgb, var(--aiv-decoration-violet) 40%, transparent);
+  border: 1px solid var(--aiv-nested-border);
   padding: 0.5rem 1rem;
   border-radius: 6px;
   display: block;
@@ -103,9 +104,9 @@ details[open]>.events-container {
   font-size: 1.3rem;
   margin-bottom: 0.85rem;
   font-weight: bold;
-  border-bottom: 1px solid color-mix(in srgb, var(--aiv-action-primary) 45%, transparent);
+  border-bottom: 1px solid var(--aiv-rule-color);
   padding-bottom: 0.4rem;
-  color: var(--aiv-legacy-green);
+  color: var(--aiv-brand-primary);
 }
 
 /* === Mobile Layout Adjustments === */

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -5,107 +5,186 @@
    =================================== */
 
 :root {
-  color-scheme: dark;
-
-  --aiv-bg-canvas: #0a0014;
-  --aiv-bg-surface: #1a0029;
-  --aiv-bg-panel: #2a0040;
-  --aiv-bg-raised: #2a0040;
-  --aiv-line-subtle: rgba(138, 43, 226, 0.4);
-  --aiv-line-strong: rgba(0, 255, 255, 0.6);
-  --aiv-grid-color: rgba(0, 255, 255, 0.2);
-
-  --aiv-text-primary: #ffffff;
-  --aiv-text-secondary: #e6e6fa;
-  --aiv-text-muted: #b19cd9;
-
-  --aiv-action-primary: #00ffff;
-  --aiv-action-secondary: #ff00ff;
-  --aiv-warning: #ffff00;
-  --aiv-risk: #ff0000;
-
-  --aiv-decoration-violet: #8a2be2;
-
-  --aiv-legacy-cyan: #00ffff;
-  --aiv-legacy-magenta: #ff00ff;
-  --aiv-legacy-green: #00ff00;
-  --aiv-legacy-yellow: #ffff00;
-  --aiv-legacy-red: #ff0000;
-  --aiv-legacy-charcoal: #1a1a1a;
-  --aiv-legacy-divider: #333333;
-  --aiv-legacy-bootstrap-muted: #6c757d;
-  --aiv-legacy-gray: #888888;
-  --aiv-legacy-dim: #666666;
-  --aiv-legacy-light-text: #cccccc;
-  --aiv-legacy-glass: rgba(138, 43, 226, 0.1);
-
   --aiv-font-body: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --aiv-font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
 }
 
-.theme-institutional-next {
+:root,
+html[data-theme="institutional-dark"],
+html[data-theme="auto"] {
   color-scheme: dark;
 
-  --aiv-bg-canvas: #0B0D0E;
-  --aiv-bg-surface: #11161A;
-  --aiv-bg-panel: #182027;
-  --aiv-bg-raised: #202A32;
-  --aiv-line-subtle: #2A343D;
-  --aiv-line-strong: #3A4652;
-  --aiv-grid-color: rgba(155, 200, 165, 0.14);
+  --aiv-bg-canvas: #070C11;
+  --aiv-bg-surface: #0D151D;
+  --aiv-bg-panel: #141F29;
+  --aiv-bg-raised: #1D2B37;
+  --aiv-line-subtle: #30414F;
+  --aiv-line-strong: #5A7182;
+  --aiv-grid-color: rgba(103, 177, 215, 0.065);
 
-  --aiv-text-primary: #F4F1E8;
-  --aiv-text-secondary: #C7D0D9;
-  --aiv-text-muted: #8A96A3;
+  --aiv-text-primary: #F4EFE3;
+  --aiv-text-secondary: #CBD5DD;
+  --aiv-text-muted: #98A6B1;
 
-  --aiv-action-primary: #9BC8A5;
-  --aiv-action-secondary: #6EA8D9;
-  --aiv-warning: #D99A2B;
-  --aiv-risk: #E05F50;
+  --aiv-brand-primary: #D4BD72;
+  --aiv-action-primary: #67B1D7;
+  --aiv-action-secondary: #89C4A2;
 
-  --aiv-decoration-violet: #8B5CF6;
+  --aiv-accent-field: #89C4A2;
+  --aiv-accent-blue: #67B1D7;
+  --aiv-accent-amber: #D1A04A;
+  --aiv-accent-red: #D36A5C;
+
+  --aiv-warning: var(--aiv-accent-amber);
+  --aiv-risk: var(--aiv-accent-red);
+
+  --aiv-decoration-violet: #665980;
+
+  --aiv-card-bg: #121D27;
+  --aiv-card-border: #3D4B56;
+  --aiv-card-hover-border: #5F7586;
+  --aiv-nested-bg: #192631;
+  --aiv-nested-border: #3D4B56;
+  --aiv-rule-color: #3D4B56;
+  --aiv-focus-ring: #67B1D7;
+  --aiv-card-shadow: none;
+  --aiv-card-hover-shadow: none;
+
+  --aiv-brand-discord-bg: #4752C4;
+  --aiv-brand-discord-text: #FFFFFF;
 }
 
-.theme-light,
-.theme-print {
+html[data-theme="institutional-light"] {
   color-scheme: light;
 
-  --aiv-bg-canvas: #F7F3EA;
+  --aiv-bg-canvas: #F8F9F6;
   --aiv-bg-surface: #FFFFFF;
-  --aiv-bg-panel: #ECE6DA;
-  --aiv-bg-raised: #E2D8C8;
-  --aiv-line-subtle: #C9BFAF;
-  --aiv-line-strong: #9E9384;
-  --aiv-grid-color: rgba(39, 92, 69, 0.12);
+  --aiv-bg-panel: #FFFFFF;
+  --aiv-bg-raised: #EAF2F6;
+  --aiv-line-subtle: #AABBC4;
+  --aiv-line-strong: #6F8794;
+  --aiv-grid-color: rgba(14, 98, 133, 0.04);
 
-  --aiv-text-primary: #121619;
-  --aiv-text-secondary: #33404A;
-  --aiv-text-muted: #52606A;
+  --aiv-text-primary: #101820;
+  --aiv-text-secondary: #2C3D48;
+  --aiv-text-muted: #4F6572;
 
-  --aiv-action-primary: #275C45;
-  --aiv-action-secondary: #24547A;
-  --aiv-warning: #87560A;
-  --aiv-risk: #9B302B;
+  --aiv-brand-primary: #655117;
+  --aiv-action-primary: #0E6285;
+  --aiv-action-secondary: #2E7051;
 
-  --aiv-decoration-violet: #5B3AA1;
+  --aiv-accent-field: #2E7051;
+  --aiv-accent-blue: #0E6285;
+  --aiv-accent-amber: #835A0E;
+  --aiv-accent-red: #9D3A32;
 
-  --aiv-legacy-cyan: #007A86;
-  --aiv-legacy-magenta: #9B1A8E;
-  --aiv-legacy-green: #007a2f;
-  --aiv-legacy-yellow: #87560A;
-  --aiv-legacy-red: #9B302B;
-  --aiv-legacy-charcoal: #FFFFFF;
-  --aiv-legacy-divider: #C9BFAF;
-  --aiv-legacy-bootstrap-muted: #52606A;
-  --aiv-legacy-gray: #52606A;
-  --aiv-legacy-dim: #6B7280;
-  --aiv-legacy-light-text: #33404A;
-  --aiv-legacy-glass: rgba(91, 58, 161, 0.1);
+  --aiv-warning: var(--aiv-accent-amber);
+  --aiv-risk: var(--aiv-accent-red);
+
+  --aiv-decoration-violet: #594071;
+
+  --aiv-card-bg: #FFFFFF;
+  --aiv-card-border: #7B96A3;
+  --aiv-card-hover-border: #6F8794;
+  --aiv-nested-bg: #EAF2F6;
+  --aiv-nested-border: #6F8794;
+  --aiv-rule-color: #AABBC4;
+  --aiv-focus-ring: #0E6285;
+  --aiv-card-shadow: 0 1px 2px rgba(16, 24, 32, 0.05), 0 8px 22px rgba(16, 24, 32, 0.045);
+  --aiv-card-hover-shadow: 0 2px 4px rgba(16, 24, 32, 0.06), 0 12px 30px rgba(16, 24, 32, 0.06);
+
+  --aiv-brand-discord-bg: #4752C4;
+  --aiv-brand-discord-text: #FFFFFF;
 }
 
-.theme-event {
-  --aiv-action-primary: var(--aiv-legacy-cyan);
-  --aiv-action-secondary: var(--aiv-legacy-magenta);
+@media (prefers-color-scheme: light) {
+  html[data-theme="auto"] {
+    color-scheme: light;
+
+    --aiv-bg-canvas: #F8F9F6;
+    --aiv-bg-surface: #FFFFFF;
+    --aiv-bg-panel: #FFFFFF;
+    --aiv-bg-raised: #EAF2F6;
+    --aiv-line-subtle: #AABBC4;
+    --aiv-line-strong: #6F8794;
+    --aiv-grid-color: rgba(14, 98, 133, 0.04);
+
+    --aiv-text-primary: #101820;
+    --aiv-text-secondary: #2C3D48;
+    --aiv-text-muted: #4F6572;
+
+    --aiv-brand-primary: #655117;
+    --aiv-action-primary: #0E6285;
+    --aiv-action-secondary: #2E7051;
+
+    --aiv-accent-field: #2E7051;
+    --aiv-accent-blue: #0E6285;
+    --aiv-accent-amber: #835A0E;
+    --aiv-accent-red: #9D3A32;
+
+    --aiv-warning: var(--aiv-accent-amber);
+    --aiv-risk: var(--aiv-accent-red);
+
+    --aiv-decoration-violet: #594071;
+
+    --aiv-card-bg: #FFFFFF;
+    --aiv-card-border: #7B96A3;
+    --aiv-card-hover-border: #6F8794;
+    --aiv-nested-bg: #EAF2F6;
+    --aiv-nested-border: #6F8794;
+    --aiv-rule-color: #AABBC4;
+    --aiv-focus-ring: #0E6285;
+    --aiv-card-shadow: 0 1px 2px rgba(16, 24, 32, 0.05), 0 8px 22px rgba(16, 24, 32, 0.045);
+    --aiv-card-hover-shadow: 0 2px 4px rgba(16, 24, 32, 0.06), 0 12px 30px rgba(16, 24, 32, 0.06);
+
+    --aiv-brand-discord-bg: #4752C4;
+    --aiv-brand-discord-text: #FFFFFF;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  html[data-theme="auto"] {
+    color-scheme: dark;
+
+    --aiv-bg-canvas: #070C11;
+    --aiv-bg-surface: #0D151D;
+    --aiv-bg-panel: #141F29;
+    --aiv-bg-raised: #1D2B37;
+    --aiv-line-subtle: #30414F;
+    --aiv-line-strong: #5A7182;
+    --aiv-grid-color: rgba(103, 177, 215, 0.065);
+
+    --aiv-text-primary: #F4EFE3;
+    --aiv-text-secondary: #CBD5DD;
+    --aiv-text-muted: #98A6B1;
+
+    --aiv-brand-primary: #D4BD72;
+    --aiv-action-primary: #67B1D7;
+    --aiv-action-secondary: #89C4A2;
+
+    --aiv-accent-field: #89C4A2;
+    --aiv-accent-blue: #67B1D7;
+    --aiv-accent-amber: #D1A04A;
+    --aiv-accent-red: #D36A5C;
+
+    --aiv-warning: var(--aiv-accent-amber);
+    --aiv-risk: var(--aiv-accent-red);
+
+    --aiv-decoration-violet: #665980;
+
+    --aiv-card-bg: #121D27;
+    --aiv-card-border: #3D4B56;
+    --aiv-card-hover-border: #5F7586;
+    --aiv-nested-bg: #192631;
+    --aiv-nested-border: #3D4B56;
+    --aiv-rule-color: #3D4B56;
+    --aiv-focus-ring: #67B1D7;
+    --aiv-card-shadow: none;
+    --aiv-card-hover-shadow: none;
+
+    --aiv-brand-discord-bg: #4752C4;
+    --aiv-brand-discord-text: #FFFFFF;
+  }
 }
 
 /* ===================================
@@ -194,7 +273,7 @@ body::after {
   left: 0;
   width: 100%;
   height: 100%;
-  background: radial-gradient(ellipse at center, color-mix(in srgb, var(--aiv-decoration-violet) 10%, transparent) 0%, transparent 70%);
+  background: radial-gradient(ellipse at center, color-mix(in srgb, var(--aiv-action-primary) 6%, transparent) 0%, transparent 70%);
   pointer-events: none;
   z-index: -1;
 }
@@ -209,7 +288,7 @@ h3,
 h4,
 h5,
 h6 {
-  color: var(--aiv-action-primary);
+  color: var(--aiv-text-primary);
   font-family: var(--aiv-font-mono);
   margin: 1.5em 0 0.75em 0;
   line-height: 1.2;
@@ -220,33 +299,38 @@ h6 {
 
 h1 {
   font-size: 2.5rem;
-  text-shadow: 0 0 30px color-mix(in srgb, var(--aiv-action-primary) 50%, transparent);
+  color: var(--aiv-text-primary);
+  text-shadow: none;
   margin-top: 0;
+}
+
+h1.glitch {
+  color: var(--aiv-brand-primary);
 }
 
 h2 {
   font-size: 2rem;
-  color: var(--aiv-action-secondary);
+  color: var(--aiv-action-primary);
 }
 
 h3 {
   font-size: 1.5rem;
-  color: var(--aiv-action-primary);
+  color: var(--aiv-text-primary);
 }
 
 h4 {
   font-size: 1.25rem;
-  color: var(--aiv-action-primary);
+  color: var(--aiv-text-primary);
 }
 
 h5 {
   font-size: 1.1rem;
-  color: var(--aiv-action-primary);
+  color: var(--aiv-text-primary);
 }
 
 h6 {
   font-size: 1rem;
-  color: var(--aiv-action-primary);
+  color: var(--aiv-text-primary);
 }
 
 p {
@@ -262,8 +346,14 @@ a {
   &:hover {
     color: var(--aiv-action-secondary);
     text-decoration: underline;
-    text-shadow: 0 0 10px color-mix(in srgb, var(--aiv-action-secondary) 50%, transparent);
   }
+}
+
+p a,
+li a {
+  text-decoration: underline;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.16em;
 }
 
 strong,
@@ -320,6 +410,12 @@ li {
   line-height: 1.6;
 }
 
+hr {
+  border: 0;
+  border-top: 1px solid var(--aiv-rule-color);
+  margin: 2rem 0;
+}
+
 /* ===================================
    CODE AND PREFORMATTED TEXT
    =================================== */
@@ -331,7 +427,7 @@ code {
   border-radius: 4px;
   color: var(--aiv-action-primary);
   font-size: 0.9em;
-  border: 1px solid var(--aiv-line-subtle);
+  border: 1px solid var(--aiv-card-border);
 }
 
 pre {
@@ -341,7 +437,7 @@ pre {
   overflow-x: auto;
   border-left: 4px solid var(--aiv-action-primary);
   backdrop-filter: blur(10px);
-  border: 1px solid var(--aiv-line-subtle);
+  border: 1px solid var(--aiv-card-border);
   margin: 1.5em 0;
 
   code {
@@ -357,15 +453,15 @@ pre {
    =================================== */
 
 blockquote {
-  border-left: 4px solid var(--aiv-action-secondary);
+  border-left: 4px solid var(--aiv-action-primary);
   margin: 1.5em 0;
   padding: 1em 1.5em;
-  background: color-mix(in srgb, var(--aiv-decoration-violet) 10%, transparent);
+  background: var(--aiv-nested-bg);
   backdrop-filter: blur(10px);
   font-style: italic;
   border-radius: 0 8px 8px 0;
-  border: 1px solid var(--aiv-line-subtle);
-  border-left: 4px solid var(--aiv-action-secondary);
+  border: 1px solid var(--aiv-nested-border);
+  border-left: 4px solid var(--aiv-action-primary);
 
   p {
     margin: 0;
@@ -407,7 +503,7 @@ blockquote {
 .site-header {
   backdrop-filter: blur(20px);
   background: color-mix(in srgb, var(--aiv-bg-surface) 80%, transparent);
-  border-bottom: 1px solid var(--aiv-line-subtle);
+  border-bottom: 1px solid var(--aiv-rule-color);
   padding: 1rem 0;
   position: sticky;
   top: 0;
@@ -424,7 +520,7 @@ blockquote {
   .site-title {
     font-family: var(--aiv-font-mono);
     font-size: 1.8rem;
-    color: var(--aiv-action-primary);
+    color: var(--aiv-brand-primary);
     text-decoration: none;
     font-weight: 700;
     text-transform: uppercase;
@@ -432,12 +528,12 @@ blockquote {
 
     &::before {
       content: "> ";
-      color: var(--aiv-action-secondary);
+      color: var(--aiv-action-primary);
       animation: blink 2s infinite;
     }
 
     &:hover {
-      text-shadow: 0 0 20px color-mix(in srgb, var(--aiv-action-primary) 70%, transparent);
+      color: var(--aiv-brand-primary);
     }
   }
 
@@ -462,18 +558,18 @@ blockquote {
 
       &:hover {
         color: var(--aiv-action-primary);
-        border-color: var(--aiv-action-primary);
-        background: color-mix(in srgb, var(--aiv-decoration-violet) 10%, transparent);
-        box-shadow: 0 0 20px color-mix(in srgb, var(--aiv-action-primary) 30%, transparent);
+        border-color: var(--aiv-card-hover-border);
+        background: color-mix(in srgb, var(--aiv-bg-raised) 65%, transparent);
       }
 
       &.active {
         color: var(--aiv-action-primary);
-        border-color: var(--aiv-action-primary);
-        background: color-mix(in srgb, var(--aiv-decoration-violet) 10%, transparent);
+        border-color: var(--aiv-card-hover-border);
+        background: color-mix(in srgb, var(--aiv-bg-raised) 65%, transparent);
       }
     }
   }
+
 }
 
 @keyframes blink {
@@ -494,9 +590,10 @@ blockquote {
    =================================== */
 
 .card {
-  background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent);
+  background: var(--aiv-card-bg);
   backdrop-filter: blur(20px);
-  border: 1px solid var(--aiv-line-subtle);
+  border: 1px solid var(--aiv-card-border);
+  box-shadow: var(--aiv-card-shadow);
   border-radius: 12px;
   padding: 1.5rem;
   margin: 1rem 0;
@@ -516,8 +613,8 @@ blockquote {
   }
 
   &:hover {
-    border-color: var(--aiv-action-primary);
-    box-shadow: 0 10px 40px color-mix(in srgb, var(--aiv-decoration-violet) 30%, transparent);
+    border-color: var(--aiv-card-hover-border);
+    box-shadow: var(--aiv-card-hover-shadow);
     transform: translateY(-5px);
 
     &::before {
@@ -529,13 +626,22 @@ blockquote {
   h4,
   h5,
   h6 {
-    color: var(--aiv-action-primary);
+    color: var(--aiv-text-primary);
     margin-top: 0;
   }
 
   p:last-child {
     margin-bottom: 0;
   }
+}
+
+.site-header .site-title::before,
+.site-title::before {
+  animation: none;
+  color: var(--aiv-action-primary);
+  font-weight: 700;
+  opacity: 1;
+  text-shadow: none;
 }
 
 /* ===================================
@@ -573,7 +679,7 @@ blockquote {
 
   &:hover {
     color: var(--aiv-bg-canvas);
-    box-shadow: 0 0 30px color-mix(in srgb, var(--aiv-action-primary) 50%, transparent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--aiv-action-primary) 22%, transparent);
     text-decoration: none;
 
     &::before {
@@ -590,7 +696,7 @@ blockquote {
     }
 
     &:hover {
-      box-shadow: 0 0 30px color-mix(in srgb, var(--aiv-action-secondary) 50%, transparent);
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--aiv-action-secondary) 22%, transparent);
     }
   }
 
@@ -619,16 +725,17 @@ blockquote {
   gap: 1rem;
   padding: 1.5rem;
   margin: 1rem 0;
-  background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent);
+  background: var(--aiv-nested-bg);
   backdrop-filter: blur(20px);
-  border-left: 4px solid var(--aiv-action-secondary);
+  border-left: 4px solid var(--aiv-card-hover-border);
   border-radius: 0 12px 12px 0;
-  border: 1px solid var(--aiv-line-subtle);
+  border: 1px solid var(--aiv-nested-border);
+  box-shadow: var(--aiv-card-shadow);
   transition: all 0.3s ease;
 
   &:hover {
-    border-color: var(--aiv-action-primary);
-    box-shadow: 0 8px 30px color-mix(in srgb, var(--aiv-decoration-violet) 30%, transparent);
+    border-color: var(--aiv-card-hover-border);
+    box-shadow: var(--aiv-card-hover-shadow);
     transform: translateY(-2px);
   }
 
@@ -639,7 +746,7 @@ blockquote {
     flex-shrink: 0;
 
     .event-month {
-      background: var(--aiv-action-primary);
+      background: var(--aiv-brand-primary);
       color: var(--aiv-bg-canvas);
       padding: 0.25rem;
       font-size: 0.8rem;
@@ -649,13 +756,13 @@ blockquote {
     }
 
     .event-day {
-      background: var(--aiv-bg-panel);
-      color: var(--aiv-action-primary);
+      background: var(--aiv-nested-bg);
+      color: var(--aiv-text-primary);
       padding: 0.5rem;
       font-size: 1.5rem;
       font-weight: 700;
       border-radius: 0 0 4px 4px;
-      border: 1px solid var(--aiv-line-subtle);
+      border: 1px solid var(--aiv-nested-border);
       border-top: none;
     }
   }
@@ -690,9 +797,10 @@ blockquote {
 
 .post-list {
   .post-item {
-    background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent);
+    background: var(--aiv-card-bg);
     backdrop-filter: blur(20px);
-    border: 1px solid var(--aiv-line-subtle);
+    border: 1px solid var(--aiv-card-border);
+    box-shadow: var(--aiv-card-shadow);
     border-radius: 12px;
     padding: 1.5rem;
     margin: 1.5rem 0;
@@ -712,9 +820,9 @@ blockquote {
     }
 
     &:hover {
-      border-color: var(--aiv-action-primary);
+      border-color: var(--aiv-card-hover-border);
       transform: translateY(-5px);
-      box-shadow: 0 10px 40px color-mix(in srgb, var(--aiv-decoration-violet) 30%, transparent);
+      box-shadow: var(--aiv-card-hover-shadow);
 
       &::before {
         left: 100%;
@@ -730,7 +838,6 @@ blockquote {
 
         &:hover {
           color: var(--aiv-action-secondary);
-          text-shadow: 0 0 15px color-mix(in srgb, var(--aiv-action-secondary) 50%, transparent);
         }
       }
     }
@@ -764,18 +871,18 @@ blockquote {
     }
 
     .post-category {
-      color: var(--aiv-action-secondary);
+      color: var(--aiv-warning);
     }
   }
 
   .post-description {
-    background: color-mix(in srgb, var(--aiv-decoration-violet) 10%, transparent);
+    background: var(--aiv-nested-bg);
     backdrop-filter: blur(10px);
     padding: 1rem;
     border-left: 4px solid var(--aiv-action-primary);
     border-radius: 0 8px 8px 0;
     margin: 1rem 0;
-    border: 1px solid var(--aiv-line-subtle);
+    border: 1px solid var(--aiv-nested-border);
 
     p {
       margin: 0;
@@ -793,14 +900,14 @@ blockquote {
     height: auto;
     border-radius: 8px;
     margin: 1rem 0;
-    border: 1px solid var(--aiv-line-subtle);
+    border: 1px solid var(--aiv-card-border);
   }
 }
 
 .post-footer {
   margin-top: 3rem;
   padding-top: 2rem;
-  border-top: 1px solid var(--aiv-line-subtle);
+  border-top: 1px solid var(--aiv-rule-color);
 
   .post-footer-content {
     display: flex;
@@ -824,7 +931,6 @@ blockquote {
 
       &:hover {
         color: var(--aiv-action-secondary);
-        text-shadow: 0 0 10px color-mix(in srgb, var(--aiv-action-secondary) 50%, transparent);
       }
     }
 
@@ -836,12 +942,11 @@ blockquote {
 
   .post-share {
     .share-link {
-      color: #1DA1F2;
+      color: var(--aiv-action-primary);
       text-decoration: none;
 
       &:hover {
         color: var(--aiv-action-primary);
-        text-shadow: 0 0 10px color-mix(in srgb, var(--aiv-action-primary) 50%, transparent);
       }
     }
   }
@@ -850,10 +955,10 @@ blockquote {
     text-align: center;
     margin: 2rem 0;
     padding: 1.5rem;
-    background: color-mix(in srgb, var(--aiv-decoration-violet) 10%, transparent);
+    background: var(--aiv-nested-bg);
     backdrop-filter: blur(10px);
     border-radius: 8px;
-    border: 1px solid var(--aiv-line-subtle);
+    border: 1px solid var(--aiv-nested-border);
 
     p {
       margin: 0;
@@ -867,8 +972,7 @@ blockquote {
         color: var(--aiv-action-primary);
 
         &:hover {
-          color: var(--aiv-action-primary);
-          text-shadow: 0 0 10px color-mix(in srgb, var(--aiv-action-primary) 50%, transparent);
+          color: var(--aiv-action-secondary);
         }
       }
     }
@@ -883,22 +987,24 @@ table {
   width: 100%;
   border-collapse: collapse;
   margin: 2rem 0;
-  background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent);
+  background: var(--aiv-card-bg);
   backdrop-filter: blur(20px);
   border-radius: 8px;
   overflow: hidden;
-  border: 1px solid var(--aiv-line-subtle);
+  border: 1px solid var(--aiv-card-border);
+  box-shadow: var(--aiv-card-shadow);
 
   th,
   td {
     padding: 1rem;
     text-align: left;
-    border-bottom: 1px solid var(--aiv-line-subtle);
+    border-bottom: 1px solid var(--aiv-rule-color);
   }
 
   th {
-    background: color-mix(in srgb, var(--aiv-bg-panel) 80%, transparent);
+    background: var(--aiv-nested-bg);
     color: var(--aiv-action-primary);
+    border-color: var(--aiv-nested-border);
     font-family: var(--aiv-font-mono);
     font-weight: 500;
     text-transform: uppercase;
@@ -927,9 +1033,9 @@ table {
 input,
 textarea,
 select {
-  background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent);
+  background: var(--aiv-card-bg);
   backdrop-filter: blur(20px);
-  border: 1px solid var(--aiv-line-subtle);
+  border: 1px solid var(--aiv-card-border);
   border-radius: 6px;
   padding: 0.75rem;
   color: var(--aiv-text-primary);
@@ -938,10 +1044,10 @@ select {
   margin-bottom: 1rem;
   transition: all 0.3s ease;
 
-  &:focus {
+    &:focus {
     outline: none;
-    border-color: var(--aiv-action-primary);
-    box-shadow: 0 0 20px color-mix(in srgb, var(--aiv-action-primary) 30%, transparent);
+    border-color: var(--aiv-focus-ring);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--aiv-focus-ring) 28%, transparent);
   }
 
   &::placeholder {
@@ -966,7 +1072,7 @@ label {
 .site-footer {
   background: color-mix(in srgb, var(--aiv-bg-canvas) 90%, transparent);
   backdrop-filter: blur(20px);
-  border-top: 1px solid var(--aiv-line-subtle);
+  border-top: 1px solid var(--aiv-rule-color);
   padding: 2rem 0;
   margin-top: 4rem;
 
@@ -990,7 +1096,6 @@ label {
 
         &:hover {
           color: var(--aiv-action-primary);
-          text-shadow: 0 0 10px color-mix(in srgb, var(--aiv-action-primary) 50%, transparent);
         }
       }
     }
@@ -1008,31 +1113,32 @@ label {
 
 // Details/Summary
 details {
-  background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent);
+  background: var(--aiv-card-bg);
   backdrop-filter: blur(20px);
-  border: 1px solid var(--aiv-line-subtle);
+  border: 1px solid var(--aiv-card-border);
+  box-shadow: var(--aiv-card-shadow);
   border-radius: 8px;
   margin: 1rem 0;
   overflow: hidden;
 
   summary {
-    background: color-mix(in srgb, var(--aiv-bg-panel) 80%, transparent);
+    background: var(--aiv-nested-bg);
     padding: 1rem;
     cursor: pointer;
     transition: all 0.3s ease;
-    border-bottom: 1px solid var(--aiv-line-subtle);
+    border-bottom: 1px solid var(--aiv-rule-color);
     color: var(--aiv-action-primary);
     font-family: var(--aiv-font-mono);
     font-weight: 500;
 
     &:hover {
-      background: var(--aiv-bg-panel);
+      background: var(--aiv-bg-raised);
       color: var(--aiv-text-primary);
     }
   }
 
   &[open] summary {
-    border-bottom: 1px solid var(--aiv-line-subtle);
+    border-bottom: 1px solid var(--aiv-rule-color);
   }
 
   .details-content {
@@ -1044,12 +1150,13 @@ details {
 .team-member {
   display: flex;
   gap: 1.5rem;
-  background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent);
+  background: var(--aiv-card-bg);
   backdrop-filter: blur(20px);
   padding: 1.5rem;
   border-radius: 12px;
-  border-left: 4px solid var(--aiv-action-primary);
-  border: 1px solid var(--aiv-line-subtle);
+  border-left: 4px solid var(--aiv-action-secondary);
+  border: 1px solid var(--aiv-card-border);
+  box-shadow: var(--aiv-card-shadow);
   margin: 1rem 0;
 
   .member-photo {
@@ -1060,11 +1167,11 @@ details {
       height: 120px;
       border-radius: 50%;
       object-fit: cover;
-      border: 2px solid var(--aiv-action-primary);
+      border: 2px solid var(--aiv-card-hover-border);
       transition: all 0.3s ease;
 
       &:hover {
-        box-shadow: 0 0 30px color-mix(in srgb, var(--aiv-action-primary) 50%, transparent);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--aiv-focus-ring) 24%, transparent);
         transform: scale(1.05);
       }
     }
@@ -1075,7 +1182,7 @@ details {
 
     h3 {
       margin: 0 0 0.5rem 0;
-      color: var(--aiv-action-primary);
+      color: var(--aiv-brand-primary);
     }
 
     .member-position {
@@ -1105,7 +1212,7 @@ details {
 
   &:hover {
     transform: translateX(10px);
-    box-shadow: 0 5px 20px color-mix(in srgb, var(--aiv-decoration-violet) 30%, transparent);
+    box-shadow: 0 5px 18px color-mix(in srgb, var(--aiv-bg-canvas) 35%, transparent);
   }
 }
 
@@ -1119,8 +1226,8 @@ details {
   a,
   span {
     padding: 0.5rem 1rem;
-    border: 1px solid var(--aiv-line-subtle);
-    background: color-mix(in srgb, var(--aiv-bg-surface) 60%, transparent);
+    border: 1px solid var(--aiv-card-border);
+    background: var(--aiv-card-bg);
     backdrop-filter: blur(20px);
     color: var(--aiv-text-secondary);
     text-decoration: none;
@@ -1129,9 +1236,9 @@ details {
     font-family: var(--aiv-font-mono);
 
     &:hover {
-      border-color: var(--aiv-action-primary);
+      border-color: var(--aiv-card-hover-border);
       color: var(--aiv-action-primary);
-      box-shadow: 0 0 15px color-mix(in srgb, var(--aiv-action-primary) 30%, transparent);
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--aiv-focus-ring) 18%, transparent);
     }
 
     &.current {
@@ -1179,11 +1286,18 @@ details {
   
   // Preserve card styling but ensure it uses dark theme
   .card,
-  .event-item,
   .post-item {
-    background: color-mix(in srgb, var(--aiv-decoration-violet) 10%, transparent) !important;
+    background: var(--aiv-card-bg) !important;
     backdrop-filter: blur(20px) !important;
-    border: 1px solid var(--aiv-line-subtle) !important;
+    border: 1px solid var(--aiv-card-border) !important;
+    box-shadow: var(--aiv-card-shadow) !important;
+  }
+
+  .event-item {
+    background: var(--aiv-nested-bg) !important;
+    backdrop-filter: blur(20px) !important;
+    border: 1px solid var(--aiv-nested-border) !important;
+    box-shadow: var(--aiv-card-shadow) !important;
   }
   
   .container {
@@ -1401,9 +1515,9 @@ details {
 
 /* Mobile Navigation Styles */
 .site-header {
-  background: var(--aiv-legacy-charcoal);
+  background: var(--aiv-bg-surface);
   padding: 1rem 0;
-  border-bottom: 2px solid var(--aiv-legacy-green);
+  border-bottom: 1px solid var(--aiv-rule-color);
   position: relative;
 }
 
@@ -1417,7 +1531,7 @@ details {
 }
 
 .site-title {
-  color: var(--aiv-legacy-green);
+  color: var(--aiv-brand-primary);
   font-family: var(--aiv-font-mono);
   font-size: 1.5rem;
   text-decoration: none;
@@ -1432,8 +1546,67 @@ details {
   align-items: center;
 }
 
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  margin-left: auto;
+  padding: 0;
+  color: var(--aiv-text-secondary);
+  background: var(--aiv-bg-surface);
+  border: 1px solid var(--aiv-card-border);
+  border-radius: 4px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.theme-toggle:hover {
+  color: var(--aiv-action-primary);
+  background: var(--aiv-bg-raised);
+  border-color: var(--aiv-card-hover-border);
+}
+
+.theme-toggle:focus-visible {
+  border-color: var(--aiv-card-hover-border);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--aiv-focus-ring) 28%, transparent);
+  outline: none;
+}
+
+.theme-icon {
+  width: 1.15rem;
+  height: 1.15rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+.theme-icon-sun {
+  display: none;
+}
+
+.theme-toggle[data-effective-theme="light"] .theme-icon-sun {
+  display: block;
+}
+
+.theme-toggle[data-effective-theme="light"] .theme-icon-moon {
+  display: none;
+}
+
+.theme-toggle[data-effective-theme="dark"] .theme-icon-moon {
+  display: block;
+}
+
 .nav-menu a {
-  color: var(--aiv-legacy-gray);
+  color: var(--aiv-text-secondary);
   text-decoration: none;
   font-family: var(--aiv-font-mono);
   transition: color 0.3s ease;
@@ -1444,7 +1617,7 @@ details {
 }
 
 .nav-menu a.active {
-  color: var(--aiv-legacy-green);
+  color: var(--aiv-action-primary);
 }
 
 .hamburger {
@@ -1463,7 +1636,7 @@ details {
 .hamburger span {
   width: 2rem;
   height: 0.25rem;
-  background: var(--aiv-legacy-green);
+  background: var(--aiv-action-primary);
   border-radius: 10px;
   transition: all 0.3s linear;
   position: relative;
@@ -1484,8 +1657,18 @@ details {
     padding-top: 4rem;
   }
 
+  .site-header .header-content,
   .header-content {
     position: relative;
+    flex-direction: row;
+    flex-wrap: nowrap;
+  }
+
+  .theme-toggle {
+    margin-left: 0;
+    margin-right: 3rem;
+    position: relative;
+    z-index: 11;
   }
 
   .hamburger {
@@ -1496,23 +1679,24 @@ details {
     transform: translateY(-50%);
   }
 
+  .site-header .nav-menu,
   .nav-menu {
     visibility: hidden;
     opacity: 0;
     position: fixed;
-    top: 0;
+    top: 4rem;
     left: 0;
     right: 0;
-    height: 100vh;
-    background: var(--aiv-legacy-charcoal);
+    height: calc(100vh - 4rem);
+    background: var(--aiv-bg-surface);
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
     gap: 2rem;
     z-index: 10;
     transition: all 0.3s ease-in-out;
     pointer-events: none;
-    padding: 1rem;
+    padding: 1.75rem 1rem 2rem;
     overflow-y: auto;
   }
 
@@ -1552,14 +1736,7 @@ details {
   }
 
   .nav-menu::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 4rem;
-    background: var(--aiv-legacy-charcoal);
-    border-bottom: 2px solid var(--aiv-legacy-green);
+    content: none;
   }
 }
 


### PR DESCRIPTION
Updates the AI Village color palette and adds a light/dark theme toggle for review.

Changes:

* Add institutional-style dark and light palettes
* Add a light/dark icon toggle
* Use system preference when no theme is saved
* Persist explicit light/dark preference
* Remove temporary legacy/vaporwave theme code from this branch
* Improve card, panel, border, focus, and link color usage
* Fix contrast-sensitive X/Twitter and Discord color usage
* Fix mobile menu positioning with the new header controls