### PR TITLE
Unify sitewide role-based typography and contrast checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "verify:redirects": "tsx scripts/verify-redirects.ts",
-    "check:internal-links": "tsx scripts/check-internal-links.ts"
+    "check:internal-links": "tsx scripts/check-internal-links.ts",
+    "check:contrast": "node scripts/contrast-check.mjs"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.0.0",

--- a/scripts/contrast-check.mjs
+++ b/scripts/contrast-check.mjs
@@ -1,0 +1,188 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const globalStylesPath = resolve(__dirname, "../src/styles/global.scss");
+const source = readFileSync(globalStylesPath, "utf8");
+
+const themeBlocks = {
+  "institutional-dark": extractBlock(":root,\nhtml[data-theme=\"institutional-dark\"],\nhtml[data-theme=\"auto\"]"),
+  "institutional-light": extractBlock("html[data-theme=\"institutional-light\"]"),
+};
+
+const themes = Object.fromEntries(
+  Object.entries(themeBlocks).map(([theme, block]) => [theme, parseHexTokens(block)])
+);
+
+const textChecks = [
+  ["primary text on canvas", "--aiv-text-primary", "--aiv-bg-canvas"],
+  ["primary text on card", "--aiv-text-primary", "--aiv-card-bg"],
+  ["secondary text on card", "--aiv-text-secondary", "--aiv-card-bg"],
+  ["muted text on card", "--aiv-text-muted", "--aiv-card-bg"],
+  ["action text on canvas", "--aiv-action-primary", "--aiv-bg-canvas"],
+  ["action text on card", "--aiv-action-primary", "--aiv-card-bg"],
+  ["brand text on canvas", "--aiv-brand-primary", "--aiv-bg-canvas"],
+  ["brand text on card", "--aiv-brand-primary", "--aiv-card-bg"],
+  ["discord text on discord bg", "--aiv-brand-discord-text", "--aiv-brand-discord-bg"],
+];
+
+const boundaryChecks = [
+  ["card border on canvas", "--aiv-card-border", "--aiv-bg-canvas"],
+  ["card border on card", "--aiv-card-border", "--aiv-card-bg"],
+  ["card hover border on card", "--aiv-card-hover-border", "--aiv-card-bg"],
+  ["nested border on nested bg", "--aiv-nested-border", "--aiv-nested-bg"],
+  ["nested border on card", "--aiv-nested-border", "--aiv-card-bg"],
+  ["rule on canvas", "--aiv-rule-color", "--aiv-bg-canvas"],
+  ["focus ring on canvas", "--aiv-focus-ring", "--aiv-bg-canvas"],
+  ["focus ring on card", "--aiv-focus-ring", "--aiv-card-bg"],
+];
+
+const checks = [
+  ...textChecks.map(([name, foreground, background]) => ({
+    kind: "text",
+    name,
+    min: 4.5,
+    foreground,
+    background,
+  })),
+  ...boundaryChecks.map(([name, foreground, background]) => ({
+    kind: "boundary",
+    name,
+    min: 3,
+    foreground,
+    background,
+  })),
+];
+
+const rows = [];
+
+for (const [theme, tokens] of Object.entries(themes)) {
+  for (const check of checks) {
+    const foreground = requireToken(tokens, check.foreground, theme);
+    const background = requireToken(tokens, check.background, theme);
+    const ratio = contrastRatio(foreground, background);
+    rows.push({
+      theme,
+      kind: check.kind,
+      name: check.name,
+      foreground: check.foreground,
+      foregroundValue: foreground,
+      background: check.background,
+      backgroundValue: background,
+      ratio,
+      min: check.min,
+      pass: ratio >= check.min,
+    });
+  }
+}
+
+printRows(rows);
+
+const failures = rows.filter((row) => !row.pass);
+if (failures.length > 0) {
+  console.error(`\nContrast check failed: ${failures.length} pair(s) below threshold.`);
+  process.exit(1);
+}
+
+console.log("\nContrast check passed.");
+
+function extractBlock(marker) {
+  const start = source.indexOf(marker);
+  if (start === -1) {
+    throw new Error(`Could not find token block marker: ${marker}`);
+  }
+
+  const open = source.indexOf("{", start);
+  if (open === -1) {
+    throw new Error(`Could not find opening brace after marker: ${marker}`);
+  }
+
+  let depth = 0;
+  for (let index = open; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "{") depth += 1;
+    if (char === "}") depth -= 1;
+    if (depth === 0) return source.slice(open + 1, index);
+  }
+
+  throw new Error(`Could not find closing brace for marker: ${marker}`);
+}
+
+function parseHexTokens(block) {
+  const tokens = {};
+  const tokenPattern = /(--aiv-[\w-]+)\s*:\s*(#[0-9a-fA-F]{3,8})\s*;/g;
+  for (const match of block.matchAll(tokenPattern)) {
+    tokens[match[1]] = normalizeHex(match[2]);
+  }
+  return tokens;
+}
+
+function requireToken(tokens, tokenName, theme) {
+  const value = tokens[tokenName];
+  if (!value) {
+    throw new Error(`Missing ${tokenName} in ${theme}`);
+  }
+  return value;
+}
+
+function normalizeHex(hex) {
+  const value = hex.toLowerCase();
+  if (value.length === 4) {
+    return `#${value[1]}${value[1]}${value[2]}${value[2]}${value[3]}${value[3]}`;
+  }
+  if (value.length === 7) return value;
+  throw new Error(`Unsupported hex token format: ${hex}`);
+}
+
+function contrastRatio(foreground, background) {
+  const foregroundLum = relativeLuminance(hexToRgb(foreground));
+  const backgroundLum = relativeLuminance(hexToRgb(background));
+  const lighter = Math.max(foregroundLum, backgroundLum);
+  const darker = Math.min(foregroundLum, backgroundLum);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function hexToRgb(hex) {
+  return {
+    r: Number.parseInt(hex.slice(1, 3), 16) / 255,
+    g: Number.parseInt(hex.slice(3, 5), 16) / 255,
+    b: Number.parseInt(hex.slice(5, 7), 16) / 255,
+  };
+}
+
+function relativeLuminance({ r, g, b }) {
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+
+function linearize(channel) {
+  return channel <= 0.03928
+    ? channel / 12.92
+    : ((channel + 0.055) / 1.055) ** 2.4;
+}
+
+function printRows(allRows) {
+  const columns = [
+    ["Theme", "theme"],
+    ["Kind", "kind"],
+    ["Pair", "name"],
+    ["Foreground", (row) => `${row.foreground}=${row.foregroundValue}`],
+    ["Background", (row) => `${row.background}=${row.backgroundValue}`],
+    ["Ratio", (row) => row.ratio.toFixed(2)],
+    ["Min", (row) => row.min.toFixed(2)],
+    ["Result", (row) => (row.pass ? "PASS" : "FAIL")],
+  ];
+
+  const widths = columns.map(([label, getter]) => {
+    const values = allRows.map((row) => String(typeof getter === "function" ? getter(row) : row[getter]));
+    return Math.max(label.length, ...values.map((value) => value.length));
+  });
+
+  const render = (values) => values.map((value, index) => String(value).padEnd(widths[index])).join("  ");
+  console.log(render(columns.map(([label]) => label)));
+  console.log(render(widths.map((width) => "-".repeat(width))));
+
+  for (const row of allRows) {
+    console.log(render(columns.map(([, getter]) => (typeof getter === "function" ? getter(row) : row[getter]))));
+  }
+}

--- a/src/layouts/EventLayout.astro
+++ b/src/layouts/EventLayout.astro
@@ -19,7 +19,7 @@ const scheduleLinks = scheduleRoutesForEvent(event.id);
 <BaseLayout title={event.data.title} description={event.data.description} canonical={url} type="event" eventDate={event.data.date} eventLocation={event.data.location}>
   <article class="event">
     <header class="event-header" style="margin-bottom: 2rem;">
-      <h1 style="color: var(--aiv-action-primary); margin: 0 0 1rem 0;">{event.data.title}</h1>
+      <h1 style="margin: 0 0 1rem 0;">{event.data.title}</h1>
       <div class="event-meta" style="display: flex; flex-wrap: wrap; gap: 2rem; margin: 1rem 0; color: var(--aiv-text-muted); font-family: var(--aiv-font-mono);">
         <div><strong style="color: var(--aiv-warning);">📅 Date:</strong> <time datetime={isoDate(event.data.date)}>{formatDate(event.data.date)}</time></div>
         {event.data.location && <div><strong style="color: var(--aiv-warning);">📍 Location:</strong> {event.data.location}</div>}

--- a/src/pages/about/conduct/index.astro
+++ b/src/pages/about/conduct/index.astro
@@ -5,10 +5,10 @@ import BaseLayout from "../../../layouts/BaseLayout.astro";
 <BaseLayout title="Code of Conduct" canonical="/about/conduct/">
   <h1>Code of Conduct</h1>
   <p>All delegates, speakers, sponsors and volunteers at AI Village are required to agree with the following code of conduct. Organizers will enforce this code throughout the event.</p>
-  <h2>THE SHORT VERSION</h2>
+  <h2>The Short Version</h2>
   <p>AI Village is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of participants in any form. Sexual language and imagery is not appropriate for any AI Village venue, including talks, workshops, parties, Twitter and other online media.</p>
   <p>Participants violating these rules may be sanctioned or expelled from the village at the discretion of the village organizers. Any violation of the DEF CON code of conduct will also result in immediate expulsion from the village and the conference at the discretion of the village and conference organizers.</p>
-  <h2>THE FULL VERSION</h2>
+  <h2>The Full Version</h2>
   <p>Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.</p>
   <p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>
   <p>Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualized images, activities, or other material.</p>

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -15,7 +15,7 @@ for (const volunteer of volunteers) {
 
 <BaseLayout title="About" canonical="/about/">
   <h1>About AI Village</h1>
-  <div style="text-align: center; margin: 2rem 0;">
+  <div class="page-intro" style="text-align: left; margin: 2rem 0;">
     <p style="color: var(--aiv-text-muted); font-size: 1.1rem;">
       AI Village is a community of hackers and data scientists working to educate the world on the use and abuse of artificial intelligence in security and privacy.
     </p>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -9,7 +9,7 @@ const posts = sortPosts(await getCollection("blog", ({ data }) => !data.draft));
 
 <BaseLayout title="Blog" canonical="/blog/">
   <h1>Blog</h1>
-  <div style="text-align: center; margin: 2rem 0;">
+  <div class="page-intro" style="text-align: left; margin: 2rem 0;">
     <p style="color: var(--aiv-text-muted); font-size: 1.1rem;">
       Research insights, event recaps, and perspectives on AI security from our community.
     </p>

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -24,7 +24,7 @@ const pastByYear = [...groupByYear(pastEvents)].sort(([a], [b]) => b.localeCompa
     </p>
     <br />
     <section class="future-events">
-      <div class="event__subtitle">Upcoming Events</div>
+      <h2 class="event__subtitle">Upcoming Events</h2>
       {futureEvents.length > 0 ? futureByYear.map(([year, yearEvents]) => (
         <details class="year-section" open>
           <summary class="year-heading">{year}</summary>
@@ -34,7 +34,7 @@ const pastByYear = [...groupByYear(pastEvents)].sort(([a], [b]) => b.localeCompa
     </section>
     <br />
     <section class="past-events">
-      <div class="event__subtitle">Past Events</div>
+      <h2 class="event__subtitle">Past Events</h2>
       {pastByYear.map(([year, yearEvents]) => (
         <details class="year-section" open>
           <summary class="year-heading">{year}</summary>
@@ -44,7 +44,7 @@ const pastByYear = [...groupByYear(pastEvents)].sort(([a], [b]) => b.localeCompa
     </section>
     <br />
     <section class="schedule-archive">
-      <div class="event__subtitle">Schedules and Talks</div>
+      <h2 class="event__subtitle">Schedules and Talks</h2>
       <div class="card">
         <ul>
           {scheduleRoutes.map((schedule) => <li><a href={schedule.path}>{schedule.label}</a></li>)}

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -14,7 +14,7 @@ const pastByYear = [...groupByYear(pastEvents)].sort(([a], [b]) => b.localeCompa
 ---
 
 <BaseLayout title="Events" canonical="/events/">
-  <section class="content">
+  <section class="content events-page">
     <h1>Events</h1>
     <p>
       If you would like to volunteer at an event

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,7 +14,7 @@ const latestPost = posts[0];
 ---
 
 <BaseLayout title="Home" canonical="/">
-  <div style="text-align: center; margin: 3rem 0;">
+  <div class="home-hero page-intro" style="text-align: center; margin: 3rem auto;">
     <h1 class="brand-display" data-text="AI VILLAGE">AI VILLAGE</h1>
     <p style="font-size: 1.2rem; color: var(--aiv-text-muted);">
       A community of hackers and data scientists working to educate the world on the use and abuse of artificial intelligence in security and privacy.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,8 +15,8 @@ const latestPost = posts[0];
 
 <BaseLayout title="Home" canonical="/">
   <div style="text-align: center; margin: 3rem 0;">
-    <h1 class="glitch cursor" data-text="AI VILLAGE">AI VILLAGE</h1>
-    <p style="font-size: 1.2rem; color: var(--aiv-text-muted); font-family: var(--aiv-font-mono);">
+    <h1 class="brand-display" data-text="AI VILLAGE">AI VILLAGE</h1>
+    <p style="font-size: 1.2rem; color: var(--aiv-text-muted);">
       A community of hackers and data scientists working to educate the world on the use and abuse of artificial intelligence in security and privacy.
     </p>
   </div>
@@ -33,7 +33,7 @@ const latestPost = posts[0];
     </style>
 
     <div class="card">
-      <h3 style="color: var(--aiv-brand-primary); margin-top: 0;">🔥 Upcoming Events</h3>
+      <h3 style="margin-top: 0;">🔥 Upcoming Events</h3>
       {upcomingEvent ? (
         <div class="event-item" style="background: var(--aiv-nested-bg); border: 1px solid var(--aiv-nested-border); border-left: 4px solid var(--aiv-card-hover-border);">
           <DateBadge date={upcomingEvent.data.date} />
@@ -50,7 +50,7 @@ const latestPost = posts[0];
     </div>
 
     <div class="card">
-      <h3 style="color: var(--aiv-brand-primary); margin-top: 0;">📝 Latest Blog Post</h3>
+      <h3 style="margin-top: 0;">📝 Latest Blog Post</h3>
       {latestPost ? (
         <>
           <h4 style="margin: 0.5rem 0;"><a href={canonicalPostPath(latestPost)}>{latestPost.data.title}</a></h4>
@@ -73,15 +73,15 @@ const latestPost = posts[0];
 
   <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.5rem; margin: 2rem 0;">
     <div class="card" style="text-align: center;">
-      <h4 style="color: var(--aiv-accent-blue);">🛡️ Security Research</h4>
+      <h4>🛡️ Security Research</h4>
       <p>Exploring vulnerabilities and defenses in AI systems through hands-on research and experimentation.</p>
     </div>
     <div class="card" style="text-align: center;">
-      <h4 style="color: var(--aiv-warning);">🎓 Education</h4>
+      <h4>🎓 Education</h4>
       <p>Teaching the security community about AI risks and the AI community about security practices.</p>
     </div>
     <div class="card" style="text-align: center;">
-      <h4 style="color: var(--aiv-action-secondary);">🤝 Community</h4>
+      <h4>🤝 Community</h4>
       <p>Building bridges between hackers, data scientists, researchers, and policy makers.</p>
     </div>
   </div>
@@ -91,7 +91,7 @@ const latestPost = posts[0];
       <hr />
 
       <section aria-labelledby="current-sponsors">
-        <h2 id="current-sponsors">CURRENT SPONSORS</h2>
+        <h2 id="current-sponsors">Current Sponsors</h2>
         <p>
           Our Current Sponsors are the companies that actively contribute to the mission of AI Village. Learn how to join our community and see past sponsors here:
           {" "}
@@ -105,7 +105,7 @@ const latestPost = posts[0];
       <hr />
 
       <section aria-labelledby="support-ai-village">
-        <h2 id="support-ai-village">SUPPORT AI VILLAGE</h2>
+        <h2 id="support-ai-village">Support AI Village</h2>
         <p>
           AI Village is supported by volunteers, researchers, builders, and organizations that contribute to AI security education and research.
         </p>
@@ -116,7 +116,7 @@ const latestPost = posts[0];
 
   <hr />
 
-  <h2 id="-get-involved">🚀 Get Involved</h2>
+  <h2 id="-get-involved">🚀 Get involved</h2>
   <div style="background: var(--aiv-card-bg); border: 1px solid var(--aiv-card-border); box-shadow: var(--aiv-card-shadow); padding: 1.5rem; border-radius: 5px; border-left: 4px solid var(--aiv-action-secondary);">
     <p><strong>Want to join our community?</strong></p>
     <ul>

--- a/src/styles/_events.scss
+++ b/src/styles/_events.scss
@@ -46,11 +46,11 @@
 }
 
 /* === Section Headings === */
-.year-heading {
+.events-page .year-heading {
   font-size: 1.2rem;
   margin-top: 1rem;
   margin-bottom: 1.5rem;
-  color: var(--aiv-action-primary) !important;
+  color: var(--aiv-text-secondary);
   font-family: var(--aiv-font-mono);
   background: var(--aiv-nested-bg) !important;
   backdrop-filter: blur(20px);
@@ -67,12 +67,12 @@
   list-style: none;
 }
 
-.year-heading::-webkit-details-marker {
+.events-page .year-heading::-webkit-details-marker {
   display: none;
 }
 
 /* Arrow icon */
-.year-heading::before {
+.events-page .year-heading::before {
   content: "▶";
   position: absolute;
   left: 0.5rem;
@@ -85,7 +85,7 @@
 }
 
 /* Rotate arrow when open */
-details[open]>.year-heading::before {
+.events-page details[open]>.year-heading::before {
   transform: translateY(-50%) rotate(90deg);
 }
 
@@ -103,14 +103,14 @@ details[open]>.events-container {
 }
 
 /* === Event Subtitle === */
-.event__subtitle {
+.events-page .event__subtitle {
   font-size: clamp(1.5rem, 2.5vw, 2.15rem);
   margin-top: 1.5rem;
   margin-bottom: 0.85rem;
   font-weight: 700;
   border-bottom: 1px solid var(--aiv-rule-color);
   padding-bottom: 0.4rem;
-  color: var(--aiv-action-primary);
+  color: var(--aiv-brand-primary);
 }
 
 /* === Mobile Layout Adjustments === */

--- a/src/styles/_events.scss
+++ b/src/styles/_events.scss
@@ -27,6 +27,8 @@
 
 .event__item {
   margin: 0;
+  font-size: clamp(1.25rem, 2vw, 1.75rem);
+  line-height: 1.15;
 }
 
 .event-location {
@@ -49,6 +51,7 @@
   margin-top: 1rem;
   margin-bottom: 1.5rem;
   color: var(--aiv-action-primary) !important;
+  font-family: var(--aiv-font-mono);
   background: var(--aiv-nested-bg) !important;
   backdrop-filter: blur(20px);
   border: 1px solid var(--aiv-nested-border);
@@ -101,12 +104,13 @@ details[open]>.events-container {
 
 /* === Event Subtitle === */
 .event__subtitle {
-  font-size: 1.3rem;
+  font-size: clamp(1.5rem, 2.5vw, 2.15rem);
+  margin-top: 1.5rem;
   margin-bottom: 0.85rem;
-  font-weight: bold;
+  font-weight: 700;
   border-bottom: 1px solid var(--aiv-rule-color);
   padding-bottom: 0.4rem;
-  color: var(--aiv-brand-primary);
+  color: var(--aiv-action-primary);
 }
 
 /* === Mobile Layout Adjustments === */

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -289,33 +289,42 @@ h4,
 h5,
 h6 {
   color: var(--aiv-text-primary);
-  font-family: var(--aiv-font-mono);
+  font-family: var(--aiv-font-body);
   margin: 1.5em 0 0.75em 0;
-  line-height: 1.2;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 1px;
+  line-height: 1.1;
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: normal;
+  text-wrap: balance;
 }
 
 h1 {
-  font-size: 2.5rem;
+  font-size: clamp(2.25rem, 4vw, 3.75rem);
   color: var(--aiv-text-primary);
+  font-weight: 700;
+  line-height: 1.05;
   text-shadow: none;
   margin-top: 0;
 }
 
-h1.glitch {
+.brand-display {
+  font-family: var(--aiv-font-mono);
+  font-size: clamp(3rem, 5vw, 4.25rem);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
   color: var(--aiv-brand-primary);
 }
 
 h2 {
-  font-size: 2rem;
+  font-size: clamp(1.75rem, 3vw, 2.75rem);
   color: var(--aiv-action-primary);
+  font-weight: 700;
 }
 
 h3 {
-  font-size: 1.5rem;
+  font-size: clamp(1.25rem, 2vw, 1.75rem);
   color: var(--aiv-text-primary);
+  font-weight: 600;
 }
 
 h4 {
@@ -448,6 +457,32 @@ pre {
   }
 }
 
+kbd,
+samp,
+.meta,
+.post-meta,
+.event-meta,
+.event-date,
+.date-badge,
+.tag,
+.badge,
+.eyebrow,
+.label,
+.member-position,
+.event-location,
+.text-mono,
+table th {
+  font-family: var(--aiv-font-mono);
+}
+
+.eyebrow,
+.label,
+.badge,
+.tag {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
 /* ===================================
    BLOCKQUOTES
    =================================== */
@@ -524,7 +559,7 @@ blockquote {
     text-decoration: none;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 2px;
+    letter-spacing: 0.08em;
 
     &::before {
       content: "> ";
@@ -549,7 +584,7 @@ blockquote {
       font-family: var(--aiv-font-mono);
       font-weight: 400;
       text-transform: uppercase;
-      letter-spacing: 1px;
+      letter-spacing: 0.08em;
       padding: 0.5rem 1rem;
       border: 1px solid transparent;
       border-radius: 4px;
@@ -657,7 +692,7 @@ blockquote {
   font-family: var(--aiv-font-mono);
   font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: 1px;
+  letter-spacing: 0.08em;
   border-radius: 6px;
   transition: all 0.3s ease;
   position: relative;
@@ -831,6 +866,8 @@ blockquote {
 
     h2 {
       margin: 0 0 0.5rem 0;
+      font-size: clamp(1.35rem, 2vw, 1.85rem);
+      line-height: 1.15;
 
       a {
         color: var(--aiv-action-primary);
@@ -895,6 +932,10 @@ blockquote {
 .post-content {
   line-height: 1.7;
 
+  h2 {
+    color: var(--aiv-text-primary);
+  }
+
   img {
     max-width: 100%;
     height: auto;
@@ -902,6 +943,10 @@ blockquote {
     margin: 1rem 0;
     border: 1px solid var(--aiv-card-border);
   }
+}
+
+.event > .event-content h2 {
+  color: var(--aiv-text-primary);
 }
 
 .post-footer {
@@ -1008,7 +1053,7 @@ table {
     font-family: var(--aiv-font-mono);
     font-weight: 500;
     text-transform: uppercase;
-    letter-spacing: 1px;
+    letter-spacing: 0.08em;
   }
 
   td {
@@ -1060,7 +1105,7 @@ label {
   font-family: var(--aiv-font-mono);
   font-size: 0.9rem;
   text-transform: uppercase;
-  letter-spacing: 1px;
+  letter-spacing: 0.08em;
   margin-bottom: 0.5rem;
   display: block;
 }
@@ -1182,7 +1227,7 @@ details {
 
     h3 {
       margin: 0 0 0.5rem 0;
-      color: var(--aiv-brand-primary);
+      color: var(--aiv-text-primary);
     }
 
     .member-position {

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -7,6 +7,8 @@
 :root {
   --aiv-font-body: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --aiv-font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  --aiv-measure-prose: 72ch;
+  --aiv-measure-wide: 96ch;
 }
 
 :root,
@@ -40,15 +42,15 @@ html[data-theme="auto"] {
 
   --aiv-decoration-violet: #665980;
 
-  --aiv-card-bg: #121D27;
-  --aiv-card-border: #3D4B56;
-  --aiv-card-hover-border: #5F7586;
-  --aiv-nested-bg: #192631;
-  --aiv-nested-border: #3D4B56;
-  --aiv-rule-color: #3D4B56;
+  --aiv-card-bg: #111C26;
+  --aiv-card-border: #586C7A;
+  --aiv-card-hover-border: #6B8090;
+  --aiv-nested-bg: #1C2C37;
+  --aiv-nested-border: #627889;
+  --aiv-rule-color: #536573;
   --aiv-focus-ring: #67B1D7;
-  --aiv-card-shadow: none;
-  --aiv-card-hover-shadow: none;
+  --aiv-card-shadow: 0 1px 0 rgba(244, 239, 227, 0.03), 0 12px 28px rgba(0, 0, 0, 0.18);
+  --aiv-card-hover-shadow: 0 1px 0 rgba(244, 239, 227, 0.04), 0 16px 36px rgba(0, 0, 0, 0.24);
 
   --aiv-brand-discord-bg: #4752C4;
   --aiv-brand-discord-text: #FFFFFF;
@@ -84,14 +86,14 @@ html[data-theme="institutional-light"] {
   --aiv-decoration-violet: #594071;
 
   --aiv-card-bg: #FFFFFF;
-  --aiv-card-border: #7B96A3;
-  --aiv-card-hover-border: #6F8794;
+  --aiv-card-border: #758F9C;
+  --aiv-card-hover-border: #6D8490;
   --aiv-nested-bg: #EAF2F6;
-  --aiv-nested-border: #6F8794;
-  --aiv-rule-color: #AABBC4;
+  --aiv-nested-border: #758F9C;
+  --aiv-rule-color: #758F9C;
   --aiv-focus-ring: #0E6285;
-  --aiv-card-shadow: 0 1px 2px rgba(16, 24, 32, 0.05), 0 8px 22px rgba(16, 24, 32, 0.045);
-  --aiv-card-hover-shadow: 0 2px 4px rgba(16, 24, 32, 0.06), 0 12px 30px rgba(16, 24, 32, 0.06);
+  --aiv-card-shadow: 0 1px 2px rgba(16, 24, 32, 0.06), 0 10px 24px rgba(16, 24, 32, 0.055);
+  --aiv-card-hover-shadow: 0 2px 4px rgba(16, 24, 32, 0.075), 0 14px 34px rgba(16, 24, 32, 0.075);
 
   --aiv-brand-discord-bg: #4752C4;
   --aiv-brand-discord-text: #FFFFFF;
@@ -128,14 +130,14 @@ html[data-theme="institutional-light"] {
     --aiv-decoration-violet: #594071;
 
     --aiv-card-bg: #FFFFFF;
-    --aiv-card-border: #7B96A3;
-    --aiv-card-hover-border: #6F8794;
+    --aiv-card-border: #758F9C;
+    --aiv-card-hover-border: #6D8490;
     --aiv-nested-bg: #EAF2F6;
-    --aiv-nested-border: #6F8794;
-    --aiv-rule-color: #AABBC4;
+    --aiv-nested-border: #758F9C;
+    --aiv-rule-color: #758F9C;
     --aiv-focus-ring: #0E6285;
-    --aiv-card-shadow: 0 1px 2px rgba(16, 24, 32, 0.05), 0 8px 22px rgba(16, 24, 32, 0.045);
-    --aiv-card-hover-shadow: 0 2px 4px rgba(16, 24, 32, 0.06), 0 12px 30px rgba(16, 24, 32, 0.06);
+    --aiv-card-shadow: 0 1px 2px rgba(16, 24, 32, 0.06), 0 10px 24px rgba(16, 24, 32, 0.055);
+    --aiv-card-hover-shadow: 0 2px 4px rgba(16, 24, 32, 0.075), 0 14px 34px rgba(16, 24, 32, 0.075);
 
     --aiv-brand-discord-bg: #4752C4;
     --aiv-brand-discord-text: #FFFFFF;
@@ -172,15 +174,15 @@ html[data-theme="institutional-light"] {
 
     --aiv-decoration-violet: #665980;
 
-    --aiv-card-bg: #121D27;
-    --aiv-card-border: #3D4B56;
-    --aiv-card-hover-border: #5F7586;
-    --aiv-nested-bg: #192631;
-    --aiv-nested-border: #3D4B56;
-    --aiv-rule-color: #3D4B56;
+    --aiv-card-bg: #111C26;
+    --aiv-card-border: #586C7A;
+    --aiv-card-hover-border: #6B8090;
+    --aiv-nested-bg: #1C2C37;
+    --aiv-nested-border: #627889;
+    --aiv-rule-color: #536573;
     --aiv-focus-ring: #67B1D7;
-    --aiv-card-shadow: none;
-    --aiv-card-hover-shadow: none;
+    --aiv-card-shadow: 0 1px 0 rgba(244, 239, 227, 0.03), 0 12px 28px rgba(0, 0, 0, 0.18);
+    --aiv-card-hover-shadow: 0 1px 0 rgba(244, 239, 227, 0.04), 0 16px 36px rgba(0, 0, 0, 0.24);
 
     --aiv-brand-discord-bg: #4752C4;
     --aiv-brand-discord-text: #FFFFFF;
@@ -317,8 +319,8 @@ h1 {
 
 h2 {
   font-size: clamp(1.75rem, 3vw, 2.75rem);
-  color: var(--aiv-action-primary);
-  font-weight: 700;
+  color: var(--aiv-text-primary);
+  font-weight: 600;
 }
 
 h3 {
@@ -360,9 +362,14 @@ a {
 
 p a,
 li a {
+  color: var(--aiv-action-primary);
   text-decoration: underline;
   text-decoration-thickness: 0.08em;
   text-underline-offset: 0.16em;
+
+  &:hover {
+    color: var(--aiv-action-primary);
+  }
 }
 
 strong,
@@ -529,6 +536,48 @@ blockquote {
 .main-content {
   padding: 2rem 0;
   min-height: calc(100vh - 200px);
+}
+
+.main-content .container>p,
+.main-content .container>ul,
+.main-content .container>ol,
+.main-content .container>blockquote,
+.main-content .container>section>p,
+.main-content .container>section>ul,
+.main-content .container>section>ol,
+.main-content .container>section>blockquote,
+.main-content .container>section>section>p,
+.main-content .container>article>p,
+.main-content .container>article>ul,
+.main-content .container>article>ol,
+.post-content>p,
+.post-content>ul,
+.post-content>ol,
+.post-content>blockquote,
+.event>.event-content>p,
+.event>.event-content>ul,
+.event>.event-content>ol,
+.event>.event-content>blockquote {
+  max-width: var(--aiv-measure-prose);
+}
+
+.page-intro,
+.post-header .post-description,
+.event-header .event-description {
+  max-width: 78ch;
+  margin-inline: 0;
+  text-align: left;
+}
+
+.home-hero.page-intro {
+  max-width: var(--aiv-measure-wide);
+  margin-inline: auto;
+  text-align: center;
+}
+
+.post-header .post-description p,
+.event-header .event-description p {
+  max-width: var(--aiv-measure-prose);
 }
 
 /* ===================================


### PR DESCRIPTION
- Replace page-scoped typography differences with a sitewide role-based heading system
- Use sans-serif content headings across Home, Blog, Events, About, and related pages
- Preserve monospace treatment for brand chrome, nav, metadata, date badges, labels, code, and technical annotations
- Keep the homepage `AI VILLAGE` hero as an explicit `.brand-display` exception
- Reduce global content H1 sizing for a more editorial page-title rhythm
- Normalize authored all-caps content headings where appropriate
- Improve typography measure and contrast checks