### PR TITLE
Update volunteer form links

### DIFF
--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -10,3 +10,5 @@ export const site = {
     "https://www.linkedin.com/company/aivillage",
   ],
 } as const;
+
+export const volunteerApplicationUrl = "https://forms.gle/sFyr1rVeqKAPXhG4A";

--- a/src/layouts/EventLayout.astro
+++ b/src/layouts/EventLayout.astro
@@ -4,6 +4,7 @@ import type { AstroComponentFactory } from "astro/runtime/server/index.js";
 import type { EventEntry } from "../utils/site";
 import { eventPath, formatDate, isoDate, truncate } from "../utils/site";
 import { scheduleRoutesForEvent } from "../data/schedules";
+import { volunteerApplicationUrl } from "../data/site";
 
 const { event, previous, next, Content } = Astro.props as {
   event: EventEntry;
@@ -43,7 +44,7 @@ const scheduleLinks = scheduleRoutesForEvent(event.id);
         <div style="display: flex; justify-content: center; gap: 1rem; flex-wrap: wrap;">
           <a href="/discord/" style="color: var(--aiv-action-primary);">Join our Discord</a>
           <span style="color: var(--aiv-text-muted);">•</span>
-          <a href="https://forms.gle/vCrz3zpR8xHCsTtJ8" target="_blank" rel="noopener noreferrer" style="color: var(--aiv-action-primary);">Volunteer Application</a>
+          <a href={volunteerApplicationUrl} target="_blank" rel="noopener noreferrer" style="color: var(--aiv-action-primary);">Volunteer Application</a>
           <span style="color: var(--aiv-text-muted);">•</span>
           <a href="/events/" style="color: var(--aiv-action-primary);">All Events</a>
         </div>

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -2,6 +2,7 @@
 import { getCollection, render } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import VolunteerCard from "../../components/VolunteerCard.astro";
+import { volunteerApplicationUrl } from "../../data/site";
 
 const volunteers = (await getCollection("volunteers")).sort((a, b) => {
   const orderDiff = a.data.order - b.data.order;
@@ -54,7 +55,7 @@ for (const volunteer of volunteers) {
     <h4 style="color: var(--aiv-action-primary); margin-top: 0;">Get Involved</h4>
     <p>AI Village welcomes help from researchers, engineers, educators, organizers, and community builders.</p>
     <div style="margin-top: 1.5rem;">
-      <a href="https://forms.gle/vCrz3zpR8xHCsTtJ8" target="_blank" rel="noopener noreferrer" style="color: var(--aiv-action-primary); font-weight: bold;">→ Submit a volunteer application</a>
+      <a href={volunteerApplicationUrl} target="_blank" rel="noopener noreferrer" style="color: var(--aiv-action-primary); font-weight: bold;">→ Submit a volunteer application</a>
     </div>
   </div>
 </BaseLayout>

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -4,6 +4,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import EventCard from "../../components/EventCard.astro";
 import { groupByYear, sortEventsAscending, sortEventsDescending } from "../../utils/site";
 import { scheduleRoutes } from "../../data/schedules";
+import { volunteerApplicationUrl } from "../../data/site";
 
 const events = await getCollection("events");
 const now = new Date();
@@ -22,7 +23,7 @@ const pastByYear = [...groupByYear(pastEvents)].sort(([a], [b]) => b.localeCompa
     <h1>Events</h1>
     <p>
       If you would like to volunteer at an event
-      <a href="https://forms.gle/vCrz3zpR8xHCsTtJ8" target="_blank" rel="noopener noreferrer">
+      <a href={volunteerApplicationUrl} target="_blank" rel="noopener noreferrer">
         submit a general volunteer application here.
       </a>
     </p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import DateBadge from "../components/DateBadge.astro";
 import SponsorGrid from "../components/SponsorGrid.astro";
 import { canonicalPostPath, eventPath, excerptFromBody, formatShortDate, getCurrentSponsors, sortEventsAscending, sortPosts } from "../utils/site";
+import { volunteerApplicationUrl } from "../data/site";
 
 const events = sortEventsAscending(await getCollection("events"));
 const posts = sortPosts(await getCollection("blog", ({ data }) => !data.draft));
@@ -128,7 +129,7 @@ const latestPost = posts[0];
       <li><a href="https://www.linkedin.com/company/aivillage">Connect on LinkedIn</a> - Connect with us on LinkedIn!</li>
       <li><a href="/events/">Attend our events</a> - DEF CON, workshops, and more</li>
       <li><a href="https://github.com/aivillage/aiv_website">Contribute</a> - Share your research and insights</li>
-      <li><a href="https://forms.gle/vCrz3zpR8xHCsTtJ8">Volunteer</a> - Help organize events and activities</li>
+      <li><a href={volunteerApplicationUrl}>Volunteer</a> - Help organize events and activities</li>
     </ul>
   </div>
 </BaseLayout>


### PR DESCRIPTION
- Replace the old site-wide volunteer form URL with the DEF CON 34 volunteer form.
- Add a shared volunteerApplicationUrl constant so the events archive, event footer, homepage, and about page all use the same current application link.